### PR TITLE
Add ARD option for non-linear kernel

### DIFF
--- a/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
+++ b/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
@@ -40,8 +40,8 @@ def make_non_linear_kernels(base_kernel_class: Type[GPy.kern.Kern], n_fidelities
     for i in range(1, n_fidelities):
         fidelity_name = 'fidelity' + str(i + 1)
         interaction_kernel = base_kernel_class(n_input_dims, active_dims=base_dims_list, ARD=ARD,
-                                               name='interaction_kernel_' + fidelity_name)
-        scale_kernel = base_kernel_class(1, active_dims=[n_input_dims], name='scale_kernel_' + fidelity_name)
+                                               name='scale_kernel_' + fidelity_name)
+        scale_kernel = base_kernel_class(1, active_dims=[n_input_dims], name='previous_fidelity_' + fidelity_name)
         bias_kernel = base_kernel_class(n_input_dims, active_dims=base_dims_list,  ARD=ARD, name='bias_kernel_' + fidelity_name)
         kernels.append(interaction_kernel * scale_kernel + bias_kernel)
     return kernels

--- a/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
+++ b/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
@@ -16,7 +16,7 @@ from ...core.interfaces import IModel, IDifferentiable
 from ..convert_lists_to_array import convert_y_list_to_array, convert_x_list_to_array
 
 
-def make_non_linear_kernels(base_kernel_class: Type[GPy.kern.Kern], n_fidelities: int, n_input_dims: int) -> List:
+def make_non_linear_kernels(base_kernel_class: Type[GPy.kern.Kern], n_fidelities: int, n_input_dims: int, ARD: bool=False) -> List:
     """
     This function takes a base kernel class and constructs the structured multi-fidelity kernels
 
@@ -31,16 +31,18 @@ def make_non_linear_kernels(base_kernel_class: Type[GPy.kern.Kern], n_fidelities
     :param base_kernel_class: GPy class definition of the kernel type to construct the kernels at
     :param n_fidelities: Number of fidelities in the model. A kernel will be returned for each fidelity
     :param n_input_dims: The dimensionality of the input.
+    :param ARD: Whether to have different lengthscales for different dimensions
     :return: A list of kernels with one entry for each fidelity starting from lowest to highest fidelity.
     """
 
     base_dims_list = list(range(n_input_dims))
-    kernels = [base_kernel_class(n_input_dims, active_dims=base_dims_list, name='kern_fidelity_1')]
+    kernels = [base_kernel_class(n_input_dims, active_dims=base_dims_list, ARD=ARD, name='kern_fidelity_1')]
     for i in range(1, n_fidelities):
         fidelity_name = 'fidelity' + str(i + 1)
-        interaction_kernel = base_kernel_class(n_input_dims, active_dims=base_dims_list, name='interaction_kernel_' + fidelity_name)
+        interaction_kernel = base_kernel_class(n_input_dims, active_dims=base_dims_list, ARD=ARD,
+                                               name='interaction_kernel_' + fidelity_name)
         scale_kernel = base_kernel_class(1, active_dims=[n_input_dims], name='scale_kernel_' + fidelity_name)
-        bias_kernel = base_kernel_class(n_input_dims, active_dims=base_dims_list, name='bias_kernel_' + fidelity_name)
+        bias_kernel = base_kernel_class(n_input_dims, active_dims=base_dims_list,  ARD=ARD, name='bias_kernel_' + fidelity_name)
         kernels.append(interaction_kernel * scale_kernel + bias_kernel)
     return kernels
 

--- a/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
+++ b/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
@@ -31,7 +31,8 @@ def make_non_linear_kernels(base_kernel_class: Type[GPy.kern.Kern], n_fidelities
     :param base_kernel_class: GPy class definition of the kernel type to construct the kernels at
     :param n_fidelities: Number of fidelities in the model. A kernel will be returned for each fidelity
     :param n_input_dims: The dimensionality of the input.
-    :param ARD: Whether to have different lengthscales for different dimensions
+    :param ARD: If True, uses different lengthscales for different dimensions. Otherwise the same lengthscale is used
+                for all dimensions. Default False.
     :return: A list of kernels with one entry for each fidelity starting from lowest to highest fidelity.
     """
 

--- a/tests/emukit/multi_fidelity/test_non_linear_models.py
+++ b/tests/emukit/multi_fidelity/test_non_linear_models.py
@@ -212,3 +212,13 @@ class TestNonLinearModel:
             return non_linear_model.get_prediction_gradients(x_full)[1]
 
         assert np.all(check_grad(wrap_func, wrap_gradients, x0) < 1e-6)
+
+
+def test_non_linear_kernel_ard():
+    """
+    Test that the kernels that act on the input space have the correct number of lengthscales when ARD is true
+    """
+    kernels = make_non_linear_kernels(GPy.kern.RBF, 2, 2, ARD=True)
+    assert len(kernels[0].lengthscale) == 2
+    assert len(kernels[1].bias_kernel_fidelity2.lengthscale) == 2
+    assert len(kernels[1].mul.scale_kernel_fidelity2.lengthscale) == 2


### PR DESCRIPTION
Add ARD option for creating non-linear multi-fidelity model kernels.

I'm not sure whether we should inherit ARD name from GPy, or choose something that is a bit clearer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
