### PR TITLE
Fix return type

### DIFF
--- a/emukit/core/loop/loop_state.py
+++ b/emukit/core/loop/loop_state.py
@@ -4,22 +4,6 @@ import numpy as np
 
 from .user_function_result import UserFunctionResult
 
-def create_loop_state(x_init: np.ndarray, y_init: np.ndarray) -> None:
-    """
-    Creates a loop state object using the provided data
-
-    :param x_init: x values for initial function evaluations.
-    :param y_init: y values for initial function evaluations
-    """
-    if x_init.shape[0] != y_init.shape[0]:
-        error_message = "X and Y should have the same length. Actual length x_init {}, y_init {}".format(x_init.shape[0], y_init.shape[0])
-        raise ValueError(error_message)
-
-    initial_results = []
-    for x, y in zip(x_init, y_init):
-        initial_results.append(UserFunctionResult(x, y))
-    return LoopState(initial_results)
-
 
 class LoopState(object):
     """
@@ -57,3 +41,20 @@ class LoopState(object):
                  in a 2d array: number of points by output dimensions.
         """
         return np.array([result.Y for result in self.results])
+
+
+def create_loop_state(x_init: np.ndarray, y_init: np.ndarray) -> LoopState:
+    """
+    Creates a loop state object using the provided data
+
+    :param x_init: x values for initial function evaluations.
+    :param y_init: y values for initial function evaluations
+    """
+    if x_init.shape[0] != y_init.shape[0]:
+        error_message = "X and Y should have the same length. Actual length x_init {}, y_init {}".format(x_init.shape[0], y_init.shape[0])
+        raise ValueError(error_message)
+
+    initial_results = []
+    for x, y in zip(x_init, y_init):
+        initial_results.append(UserFunctionResult(x, y))
+    return LoopState(initial_results)


### PR DESCRIPTION
Changed return type of `create_loop_state` from `None` to `LoopState`. Moved function to end of file so `LoopState` class is already defined when using type annotation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
