### PR TITLE
Enable documentation hosting on RTD

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
         return MagicMock()
 
-MOCK_MODULES = ['matplotlib', 'pylab']
+MOCK_MODULES = ['matplotlib', 'pylab', 'matplotlib.pyplot']
 sys.modules.update((module_name, Mock()) for module_name in MOCK_MODULES)
 
 # -- Project information -----------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,17 @@ import shutil
 import sys
 from os.path import abspath, dirname
 
+# -- Mock graphing modules - workaround for wrong behavior of some dependencies
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+MOCK_MODULES = ['matplotlib', 'pylab']
+sys.modules.update((module_name, Mock()) for module_name in MOCK_MODULES)
+
 # -- Project information -----------------------------------------------------
 
 project = 'emukit'

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: latest
+
+python:
+    version: 3.6

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -1,3 +1,7 @@
+# package requirements
+-r requirements.txt
+
+# documentation tools
 Sphinx>=1.7.5
 nbsphinx>=0.3.4
 sphinx-autodoc-typehints>=1.3.0


### PR DESCRIPTION
*Issue #, if available:* #12 

*Description of changes:* RTD build required quite a few tweaks. Result can be found at https://emukit.readthedocs.io/en/apaleyes-rtd


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
