### PR TITLE
Fix return type of predict in IModel interface

### DIFF
--- a/emukit/core/interfaces/models.py
+++ b/emukit/core/interfaces/models.py
@@ -7,11 +7,12 @@ from typing import Tuple
 
 
 class IModel:
-    def predict(self, X: np.ndarray) -> np.ndarray:
+    def predict(self, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """
-        Predict values for given points
+        Predict mean and variance values for given points
 
-        :param X: points to run prediction for
+        :param X: array of shape (n_points x n_inputs) of points to run prediction for
+        :return: Tuple of mean and variance which are 2d arrays of shape (n_points x n_outputs)
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Return type was wrong for `IModel.predict`. This PR corrects that and expands the docstring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
