### PR TITLE
Update model at the end of the loop

### DIFF
--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -66,6 +66,7 @@ class OuterLoop(object):
             self.loop_state.update(results)
             self.custom_step()
 
+        self.model_updater.update(self.loop_state)
         _log.info("Finished outer loop")
 
     def get_next_points(self, results: List[UserFunctionResult]) -> np.ndarray:


### PR DESCRIPTION
This PR makes sure the model is up to date with all observations at the end of the loop. 

Not sure if we should actually do this so would like other people's opinion. If the model training takes a long time and we are sure that we don't need the model to be up to date we would not want to do this but in most cases it seems a sensible thing to do.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
