### PR TITLE
Change multi-source candidate point calculator to an acquisition optimizer

### DIFF
--- a/emukit/core/loop/__init__.py
+++ b/emukit/core/loop/__init__.py
@@ -8,4 +8,4 @@ from .outer_loop import OuterLoop
 from .user_function_result import UserFunctionResult
 from .stopping_conditions import StoppingCondition, FixedIterationsStoppingCondition
 from .model_updaters import ModelUpdater, FixedIntervalUpdater
-from .candidate_point_calculators import CandidatePointCalculator, Sequential, MultiSourceSequential
+from .candidate_point_calculators import CandidatePointCalculator, Sequential

--- a/emukit/core/loop/candidate_point_calculators.py
+++ b/emukit/core/loop/candidate_point_calculators.py
@@ -7,10 +7,9 @@ import abc
 import numpy as np
 
 from .loop_state import LoopState
-from .. import ParameterSpace, InformationSourceParameter
 from ..acquisition import Acquisition
 from ..interfaces import IModel
-from ..optimization import AcquisitionOptimizer
+from ..optimization.acquisition_optimizer import AcquisitionOptimizerBase
 
 
 class CandidatePointCalculator(abc.ABC):
@@ -28,7 +27,7 @@ class CandidatePointCalculator(abc.ABC):
 
 class Sequential(CandidatePointCalculator):
     """ This candidate point calculator chooses one candidate point at a time """
-    def __init__(self, acquisition: Acquisition, acquisition_optimizer: AcquisitionOptimizer) -> None:
+    def __init__(self, acquisition: Acquisition, acquisition_optimizer: AcquisitionOptimizerBase) -> None:
         """
         :param acquisition: Acquisition function to maximise
         :param acquisition_optimizer: Optimizer of acquisition function
@@ -56,7 +55,7 @@ class GreedyBatchPointCalculator(CandidatePointCalculator):
     the end of collecting a batch but if you use a model where training the model with the same data leads to different
     predictions, the model behaviour will be modified.
     """
-    def __init__(self, model: IModel, acquisition: Acquisition, acquisition_optimizer: AcquisitionOptimizer,
+    def __init__(self, model: IModel, acquisition: Acquisition, acquisition_optimizer: AcquisitionOptimizerBase,
                  batch_size: int=1):
         """
         :param model: Model that is used by the acquisition function
@@ -93,60 +92,3 @@ class GreedyBatchPointCalculator(CandidatePointCalculator):
         # Reset data
         self.model.update_data(*original_data)
         return np.concatenate(new_xs, axis=0)
-
-
-class MultiSourceSequential(CandidatePointCalculator):
-    """
-    Finds the location and information source of the next point to evaluate
-    """
-    def __init__(self, acquisition: Acquisition, acquisition_optimizer: AcquisitionOptimizer, space: ParameterSpace) -> None:
-        """
-        :param acquisition: Acquisition function to find maximum of
-        :param acquisition_optimizer: Optimizer of the acquisition function
-        :param space: Domain to search for maximum over
-        """
-        self.acquisition = acquisition
-        self.acquisition_optimizer = acquisition_optimizer
-        self.space = space
-        self.source_parameter = self._get_information_source_parameter()
-        self.n_sources = np.array(self.source_parameter.domain).size
-
-    def _get_information_source_parameter(self) -> InformationSourceParameter:
-        """
-        :return: The parameter containing the index of the information source
-        """
-        source_parameter = [param for param in self.space.parameters if isinstance(param, InformationSourceParameter)]
-        if len(source_parameter) == 0:
-            raise ValueError('No source parameter found')
-        return source_parameter[0]
-
-    def compute_next_points(self, loop_state: LoopState=None, context: dict=None) -> np.ndarray:
-        """
-        Computes the location and source of the next point to evaluate by finding the optimum input location at each
-        information source, then picking the information source where the value of the acquisition at the optimum input
-        location is highest.
-
-        :param loop_state: Object that tracks the state of the loop. Currently unused
-        :param context: Contains variables to fix through optimization of acquisition function. The dictionary key is
-                        the parameter name and the value is the value to fix the parameter to.
-        :return: A list of function inputs to evaluate next
-        """
-        f_mins = np.zeros((len(self.source_parameter.domain)))
-        x_opts = []
-
-        if context is None:
-            context = dict()
-        elif self.source_parameter.name in context:
-            # Information source parameter already has a context so just optimise the acquisition at this source
-            return self.acquisition_optimizer.optimize(self.acquisition, context)[0]
-
-        # Optimize acquisition for each information source
-        for i in range(len(self.source_parameter.domain)):
-            # Fix the source using a dictionary, the key is the name of the parameter to fix and the value is the
-            # value to which the parameter is fixed
-            context[self.source_parameter.name] = self.source_parameter.domain[i]
-            x, f_mins[i] = self.acquisition_optimizer.optimize(self.acquisition, context)
-            x_opts.append(x)
-        best_source = np.argmin(f_mins)
-        return x_opts[best_source]
-

--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -15,7 +15,19 @@ import logging
 _log = logging.getLogger(__name__)
 
 
-class AcquisitionOptimizer(object):
+class AcquisitionOptimizerBase:
+    def optimize(self, acquisition: Acquisition, context: dict = None) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Optimizes the acquisition function, taking into account gradients if it supports them
+
+        :param acquisition: The acquisition function to be optimized
+        :param context: Optimization context, determines whether any variable values should be fixed during the optimization
+        :return: Tuple of (location of optimum, acquisition value at optimum)
+        """
+        pass
+
+
+class AcquisitionOptimizer(AcquisitionOptimizerBase):
     """ Optimizes the acquisition function """
     def __init__(self, space: ParameterSpace, **kwargs) -> None:
         self.space = space

--- a/emukit/core/optimization/multi_source_acquisition_optimizer.py
+++ b/emukit/core/optimization/multi_source_acquisition_optimizer.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import Tuple
+
+import numpy as np
+
+from .. import InformationSourceParameter, ParameterSpace
+from ..acquisition import Acquisition
+from .acquisition_optimizer import AcquisitionOptimizer, AcquisitionOptimizerBase
+
+
+class MultiSourceAcquisitionOptimizer(AcquisitionOptimizerBase):
+    """
+    Optimizes the acquisition function by finding the optimum input location at each information source, then picking
+    the information source where the value of the acquisition at the optimum input location is highest.
+    """
+    def __init__(self, acquisition_optimizer: AcquisitionOptimizer, space: ParameterSpace) -> None:
+        """
+        :param acquisition_optimizer: Optimizer to use for optimizing the acquisition once the information source
+                                      has been fixed
+        :param space: Domain to search for maximum over
+        """
+        self.acquisition_optimizer = acquisition_optimizer
+        self.space = space
+        self.source_parameter = self._get_information_source_parameter()
+        self.n_sources = np.array(self.source_parameter.domain).size
+
+    def _get_information_source_parameter(self) -> InformationSourceParameter:
+        """
+        :return: The parameter containing the index of the information source
+        """
+        source_parameter = [param for param in self.space.parameters if isinstance(param, InformationSourceParameter)]
+        if len(source_parameter) == 0:
+            raise ValueError('No source parameter found')
+        return source_parameter[0]
+
+    def optimize(self, acquisition: Acquisition, context: dict=None) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Computes the location and source of the next point to evaluate by finding the optimum input location at each
+        information source, then picking the information source where the value of the acquisition at the optimum input
+        location is highest.
+
+        :param acquisition: The acquisition function to be optimized
+        :param context: Contains variables to fix through optimization of acquisition function. The dictionary key is
+                        the parameter name and the value is the value to fix the parameter to.
+        :return: A tuple of (location of optimum, acquisition value at optimum)
+        """
+        f_mins = np.zeros((len(self.source_parameter.domain)))
+        x_opts = []
+
+        if context is None:
+            context = dict()
+        elif self.source_parameter.name in context:
+            # Information source parameter already has a context so just optimise the acquisition at this source
+            return self.acquisition_optimizer.optimize(acquisition, context)
+
+        # Optimize acquisition for each information source
+        for i in range(len(self.source_parameter.domain)):
+            # Fix the source using a dictionary, the key is the name of the parameter to fix and the value is the
+            # value to which the parameter is fixed
+            context[self.source_parameter.name] = self.source_parameter.domain[i]
+            x, f_mins[i] = self.acquisition_optimizer.optimize(acquisition, context)
+            x_opts.append(x)
+        best_source = np.argmin(f_mins)
+        return x_opts[best_source], np.min(f_mins)

--- a/integration_tests/emukit/experimental_design/test_multi_source_experimental_design.py
+++ b/integration_tests/emukit/experimental_design/test_multi_source_experimental_design.py
@@ -1,0 +1,43 @@
+import GPy
+import numpy as np
+
+from emukit.core.loop import FixedIntervalUpdater, OuterLoop
+from emukit.core.loop.candidate_point_calculators import GreedyBatchPointCalculator
+from emukit.core.loop.loop_state import LoopState
+from emukit.core.optimization import AcquisitionOptimizer
+from emukit.core.optimization.multi_source_acquisition_optimizer import MultiSourceAcquisitionOptimizer
+from emukit.experimental_design import RandomDesign
+from emukit.experimental_design.model_based.acquisitions import ModelVariance
+from emukit.model_wrappers import GPyModelWrapper
+from emukit.test_functions import multi_fidelity_forrester_function
+
+
+def test_multi_source_batch_experimental_design():
+    objective, space = multi_fidelity_forrester_function()
+
+    # Create initial data
+    random_design = RandomDesign(space)
+    x_init = random_design.get_samples(10)
+    intiial_results = objective.evaluate(x_init)
+    y_init = np.array([res.Y for res in intiial_results])
+
+    # Create multi source acquisition optimizer
+    acquisition_optimizer = AcquisitionOptimizer(space)
+    multi_source_acquisition_optimizer = MultiSourceAcquisitionOptimizer(acquisition_optimizer, space)
+
+    # Create GP model
+    gpy_model = GPy.models.GPRegression(x_init, y_init)
+    model = GPyModelWrapper(gpy_model)
+
+    # Create acquisition
+    acquisition = ModelVariance(model)
+
+    # Create batch candidate point calculator
+    batch_candidate_point_calculator = GreedyBatchPointCalculator(model, acquisition,
+                                                                  multi_source_acquisition_optimizer, batch_size=5)
+
+    initial_loop_state = LoopState(intiial_results)
+    loop = OuterLoop(batch_candidate_point_calculator, FixedIntervalUpdater(model, 1), initial_loop_state)
+
+    loop.run_loop(objective, 10)
+    assert loop.loop_state.X.shape[0] == 60


### PR DESCRIPTION
This PR converts the multi source candidate point calculator to an acquisition optimizer as it seems more natural and allows us to do batch multi-fidelity loops, see integration tests for an example. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
