### PR TITLE
Allow model updater to update from any field in loop state

### DIFF
--- a/emukit/core/loop/model_updaters.py
+++ b/emukit/core/loop/model_updaters.py
@@ -3,6 +3,7 @@
 
 
 import abc
+from typing import Callable
 
 from . import LoopState
 from ..interfaces import IModel
@@ -10,6 +11,7 @@ from ..interfaces import IModel
 
 import logging
 _log = logging.getLogger(__name__)
+
 
 class ModelUpdater(abc.ABC):
     @abc.abstractmethod
@@ -24,19 +26,27 @@ class ModelUpdater(abc.ABC):
 
 class FixedIntervalUpdater(ModelUpdater):
     """ Updates hyper-parameters every nth iteration, where n is defined by the user """
-    def __init__(self, model: IModel, interval: int = 1) -> None:
+    def __init__(self, model: IModel, interval: int=1, targets_extractor_fcn: Callable=None) -> None:
         """
         :param model: Emukit emulator model
         :param interval: Number of function evaluations between optimizing model hyper-parameters
+        :param targets_extractor_fcn: A lambda function that takes in loop state and returns the training targets.
+                                      Defaults to a function returning loop_state.Y
         """
         self.model = model
         self.interval = interval
+
+        if targets_extractor_fcn is None:
+            self.targets_extractor_fcn = lambda loop_state: loop_state.Y
+        else:
+            self.targets_extractor_fcn = targets_extractor_fcn
 
     def update(self, loop_state: LoopState) -> None:
         """
         :param loop_state: Object that contains current state of the loop
         """
-        self.model.update_data(loop_state.X, loop_state.Y)
+        targets = self.targets_extractor_fcn(loop_state)
+        self.model.update_data(loop_state.X, targets)
         if (loop_state.iteration % self.interval) == 0:
             _log.info("Updating parameters of the model")
             self.model.optimize()

--- a/emukit/examples/cost_sensitive_bayesian_optimization_loop.py
+++ b/emukit/examples/cost_sensitive_bayesian_optimization_loop.py
@@ -45,7 +45,7 @@ class CostSensitiveBayesianOptimizationLoop(OuterLoop):
         if model_updater_objective is None:
             model_updater_objective = FixedIntervalUpdater(model_objective, 1)
         if model_updater_cost is None:
-            model_updater_cost = FixedIntervalUpdater(model_cost, 1)
+            model_updater_cost = FixedIntervalUpdater(model_cost, 1, lambda state: state.cost)
 
         if candidate_point_calculator is None:
             acquisition_optimizer = AcquisitionOptimizer(space)


### PR DESCRIPTION
Currently the cost model in the cost sensitive loop is trained on "Y" values whereas it should be trained on "cost" values. This PR fixes that. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
