### PR TITLE
Make test less flaky

### DIFF
--- a/integration_tests/emukit/bayesian_optimization/test_local_penalization_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_local_penalization_loop.py
@@ -1,4 +1,5 @@
 import GPy
+import numpy as np
 
 from emukit.bayesian_optimization.acquisitions import ExpectedImprovement
 from emukit.bayesian_optimization.loops import BayesianOptimizationLoop
@@ -8,6 +9,7 @@ from emukit.test_functions import branin_function
 
 
 def test_local_penalization():
+    np.random.seed(123)
     branin_fcn, parameter_space = branin_function()
     random_design = RandomDesign(parameter_space)
     x_init = random_design.get_samples(10)
@@ -15,6 +17,7 @@ def test_local_penalization():
     y_init = branin_fcn(x_init)
 
     gpy_model = GPy.models.GPRegression(x_init, y_init)
+    gpy_model.Gaussian_noise.fix(1)
     model = GPyModelWrapper(gpy_model)
 
     base_acquisition = ExpectedImprovement(model)


### PR DESCRIPTION
This test seems to be flaky as we run into linear algebra errors during the GP hyperparameter optimization. I fix the likelihood variance of the model and fix the random seed in this PR in an attempt to make it less flaky.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
