### PR TITLE
install gpy plotting dependencies

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,7 @@
 numpy==1.14.5
+# This is unfortunate - we don't need matplotlib
+# but until GPy and GPyOpt get their dependencies straight
+# we need GPy's plotting extra to ensure smooth installation
 GPy[plotting]==1.9.5
 GPyOpt==1.2.5
 emcee==2.2.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.14.5
-GPy==1.9.5
+GPy[plotting]==1.9.5
 GPyOpt==1.2.5
 emcee==2.2.1
 scipy==1.1.0

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -4,8 +4,3 @@ flake8>=3.5.0
 pytest==3.5.1
 pytest-cov==2.5.1
 mock==2.0.0
-
-# This is unfortunate - we don't need matplotlib
-# but until GPy and GPyOpt get their dependencies straight
-# we need this to make sure tests are running
-matplotlib>=1.5.3


### PR DESCRIPTION
Address issue #100. Installs GPy with matplotlib dependencies to avoid import error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
