### PR TITLE
Do not merge: investigating mac builds timing further

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - '3.6'
 before_install: |
  if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-   brew update
    # Recommended for pyenv
    brew outdated openssl || brew upgrade openssl
    brew outdated readline || brew upgrade readline
@@ -45,4 +44,4 @@ jobs:
       env: PYTHON=3.5.2
     - os: osx
       language: generic
-      env: PYTHON=3.6.6
+      env: PYTHON=3.6.5


### PR DESCRIPTION
*Issue #, if available:* #125 

*Description of changes:* This builds on top of #122 . From [here](https://github.com/pypa/pipenv/issues/2593) is seems as though pyenv on Macs is just behind in terms of python version, so perhaps going down a minor release would help?

ANother option to consider is just "brew update pyenv", which I'll try next.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
