### PR TITLE
Added attribute to fix language stats on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Currently our repo is reported as 96% Jupyter notebook, while we should be recognized as a Python lib. This change removes notebook files from the statistics. Sources: https://github.com/github/linguist/issues/3316, https://github.com/soniclavier/bigdata-notebook/blob/master/.gitattributes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
