### PR TITLE
Fix comment about acquisition optimizer return values

### DIFF
--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -23,7 +23,7 @@ class AcquisitionOptimizerBase:
         :param acquisition: The acquisition function to be optimized
         :param context: Optimization context.
                         Determines whether any variable values should be fixed during the optimization
-        :return: Tuple of (location of optimum, acquisition value at optimum)
+        :return: Tuple of (location of maximum, acquisition value at maximizer)
         """
         pass
 
@@ -42,7 +42,7 @@ class AcquisitionOptimizer(AcquisitionOptimizerBase):
         :param acquisition: The acquisition function to be optimized
         :param context: Optimization context.
                         Determines whether any variable values should be fixed during the optimization
-        :return: Tuple of (location of optimum, acquisition value at optimum)
+        :return: Tuple of (location of maximum, acquisition value at maximizer)
         """
 
         # Take negative of acquisition function because they are to be maximised and the optimizers minimise
@@ -81,7 +81,7 @@ class AcquisitionOptimizer(AcquisitionOptimizerBase):
         # We may have changed the value of x, so we need to re-evaluate acquisition to make sure f_min is correct
         rounded_f_min = acquisition.evaluate(rounded_x)
 
-        return rounded_x, rounded_f_min
+        return rounded_x, -rounded_f_min
 
     def _validate_context_parameters(self, context):
         for context_name, context_value in context.items():

--- a/emukit/core/optimization/multi_source_acquisition_optimizer.py
+++ b/emukit/core/optimization/multi_source_acquisition_optimizer.py
@@ -45,9 +45,9 @@ class MultiSourceAcquisitionOptimizer(AcquisitionOptimizerBase):
         :param acquisition: The acquisition function to be optimized
         :param context: Contains variables to fix through optimization of acquisition function. The dictionary key is
                         the parameter name and the value is the value to fix the parameter to.
-        :return: A tuple of (location of optimum, acquisition value at optimum)
+        :return: A tuple of (location of maximum, acquisition value at maximizer)
         """
-        f_mins = np.zeros((len(self.source_parameter.domain)))
+        f_maxs = np.zeros((len(self.source_parameter.domain)))
         x_opts = []
 
         if context is None:
@@ -61,7 +61,7 @@ class MultiSourceAcquisitionOptimizer(AcquisitionOptimizerBase):
             # Fix the source using a dictionary, the key is the name of the parameter to fix and the value is the
             # value to which the parameter is fixed
             context[self.source_parameter.name] = self.source_parameter.domain[i]
-            x, f_mins[i] = self.acquisition_optimizer.optimize(acquisition, context)
+            x, f_maxs[i] = self.acquisition_optimizer.optimize(acquisition, context)
             x_opts.append(x)
-        best_source = np.argmin(f_mins)
-        return x_opts[best_source], np.min(f_mins)
+        best_source = np.argmax(f_maxs)
+        return x_opts[best_source], np.max(f_maxs)


### PR DESCRIPTION
*Issue #, if available:* #151

*Description of changes:* Correction to comment, we actually return the negative of the acquisition value at the optimum rather than the acquisition value itself.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
