### PR TITLE
Add get_bounds method

### DIFF
--- a/emukit/bayesian_optimization/local_penalization_calculator.py
+++ b/emukit/bayesian_optimization/local_penalization_calculator.py
@@ -86,7 +86,7 @@ def _estimate_lipschitz_constant(space: ParameterSpace, model: IDifferentiable):
 
     # Run optimizer to find point of highest gradient
     res = scipy.optimize.minimize(lambda x: negative_gradient_norm(x[None, :]), x0,
-                                  bounds=space.convert_to_gpyopt_design_space().get_bounds(),
+                                  bounds=space.get_bounds(),
                                   options={'maxiter': MAX_ITER})
     lipschitz_constant = -res.fun[0]
 

--- a/emukit/core/categorical_parameter.py
+++ b/emukit/core/categorical_parameter.py
@@ -3,7 +3,7 @@
 
 
 import numpy as np
-from typing import List
+from typing import List, Tuple
 
 from .encodings import Encoding
 from .parameter import Parameter
@@ -34,6 +34,14 @@ class CategoricalParameter(Parameter):
 
     def round(self, x: np.ndarray) -> np.ndarray:
         return self.encoding.round(x)
+
+    @property
+    def bounds(self) -> List[Tuple]:
+        """
+        Returns a list of tuples containing where each tuple contains the minimum and maximum of the variables used to
+        encode the categorical parameter..
+        """
+        return [(param.min, param.max) for param in self._cont_params]
 
     @property
     def dimension(self) -> int:

--- a/emukit/core/continuous_parameter.py
+++ b/emukit/core/continuous_parameter.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Union
+from typing import Union, Tuple, List
 
 import numpy as np
 
@@ -31,3 +31,10 @@ class ContinuousParameter(Parameter):
         :return: A boolean value which indicates whether all points lie in the domain
         """
         return np.all([(self.min < x), (self.max > x)], axis=0)
+
+    @property
+    def bounds(self) -> List[Tuple]:
+        """
+        Returns a list containing one tuple of minimum and maximum values parameter can take
+        """
+        return [(self.min, self.max)]

--- a/emukit/core/discrete_parameter.py
+++ b/emukit/core/discrete_parameter.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Iterable, Union
+from typing import Iterable, Union, Tuple, List
 
 import numpy as np
 
@@ -31,6 +31,13 @@ class DiscreteParameter(Parameter):
         if np.isscalar(x):
             x = [x]
         return set(x).issubset(set(self.domain))
+
+    @property
+    def bounds(self) -> List[Tuple]:
+        """
+        Returns a list containing one tuple of min and max values parameter can take
+        """
+        return [(min(self.domain), max(self.domain))]
 
 
 class InformationSourceParameter(DiscreteParameter):

--- a/emukit/core/parameter.py
+++ b/emukit/core/parameter.py
@@ -3,7 +3,7 @@
 
 
 import numpy as np
-from typing import List
+from typing import List, Tuple
 
 
 class Parameter(object):
@@ -20,6 +20,13 @@ class Parameter(object):
         Gives the list of single dimensional model parameters the parameter corresponds to.
         """
         return [self]
+
+    @property
+    def bounds(self) -> List[Tuple]:
+        """
+        Returns bounds of the parameter in a form of list of tuples
+        """
+        raise NotImplemented
 
     def round(self, x: np.ndarray) -> np.ndarray:
         """

--- a/emukit/core/parameter_space.py
+++ b/emukit/core/parameter_space.py
@@ -1,8 +1,7 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-
-from typing import List
+import itertools
+from typing import List, Tuple
 
 import numpy as np
 import GPyOpt
@@ -64,6 +63,19 @@ class ParameterSpace(object):
             if param.name == name:
                 return param
         raise ValueError('Parameter with name ' + name + ' not found.')
+
+    def get_bounds(self) -> List[Tuple]:
+        """
+        Returns a list of tuples containing the min and max value each parameter can take.
+
+        If the parameter space contains categorical variables, the min and max values correspond to each variable used
+        to encode the categorical variables.
+        """
+
+        # bounds is a list of lists
+        bounds = [param.bounds for param in self.parameters]
+        # Convert list of lists to one list
+        return list(itertools.chain.from_iterable(bounds))
 
     def round(self, x: np.ndarray) -> np.ndarray:
         """

--- a/tests/emukit/core/test_parameter_space.py
+++ b/tests/emukit/core/test_parameter_space.py
@@ -1,7 +1,8 @@
 import pytest
 import numpy as np
 
-from emukit.core import ContinuousParameter, ParameterSpace, InformationSourceParameter
+from emukit.core import ContinuousParameter, ParameterSpace, InformationSourceParameter, DiscreteParameter, \
+    CategoricalParameter, OneHotEncoding
 
 
 @pytest.fixture
@@ -49,3 +50,11 @@ def test_duplicate_parameter_names_fail():
 
     with pytest.raises(ValueError):
         ParameterSpace([p1, p2])
+
+
+def test_get_bounds():
+    p1 = ContinuousParameter('c', 1.0, 5.0)
+    p2 = DiscreteParameter('d', [1, 2, 3])
+    p3 = CategoricalParameter('cat', OneHotEncoding(['Maine Coon', 'Siamese']))
+    space = ParameterSpace([p1, p2, p3])
+    assert space.get_bounds() == [(1., 5.), (1., 3.), (0, 1), (0, 1)]

--- a/tests/emukit/test_acquisitions.py
+++ b/tests/emukit/test_acquisitions.py
@@ -40,7 +40,7 @@ acquisition_tests = [acquisition_test_tuple('negative_lower_confidence_bound_acq
 # Vanilla bq model for squared correlation test
 @pytest.fixture
 def vanilla_bq_model(gpy_model, continuous_space, n_dims):
-    integral_bounds = continuous_space.convert_to_gpyopt_design_space().get_bounds()
+    integral_bounds = continuous_space.get_bounds()
     model = convert_gpy_model_to_emukit_model(gpy_model.model, integral_bounds)
     return VanillaBayesianQuadrature(model)
 


### PR DESCRIPTION
Add get_bounds method to parameter space instead of having to convert to gpyopt design space.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
