### PR TITLE
Don't update models twice per iteration

### DIFF
--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -87,7 +87,7 @@ class OuterLoop(object):
             self.loop_state.update(results)
             self.iteration_end_event(self, self.loop_state)
 
-            self._update_models()
+        self._update_models()
         _log.info("Finished outer loop")
 
     def _update_models(self):


### PR DESCRIPTION
*Description of changes:* The loop current updates the models twice per iteration. I think the cause of this was a simple white space error - the final model update should be done outside the for loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
