### PR TITLE
some fixes to BQ

### DIFF
--- a/emukit/quadrature/methods/vanilla_bq.py
+++ b/emukit/quadrature/methods/vanilla_bq.py
@@ -60,7 +60,7 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel):
         """
         integral_mean, kernel_mean_X = self._compute_integral_mean_and_kernel_mean()
         integral_var = self.base_gp.kern.qKq() - np.square(lapack.dtrtrs(self.base_gp.gram_chol(), kernel_mean_X.T,
-                                                           lower=1)[0]).sum(axis=0, keepdims=True).T
+                                                           lower=1)[0]).sum(axis=0, keepdims=True)[0][0]
         return integral_mean, integral_var
 
     # helpers

--- a/emukit/test_functions/quadrature_functions.py
+++ b/emukit/test_functions/quadrature_functions.py
@@ -31,15 +31,18 @@ def _hennig1D(x: np.ndarray) -> np.ndarray:
 
 
 def circular_gaussian(mean: np.float = 0., variance: np.float = 1.) -> Tuple[UserFunctionWrapper, Callable]:
-    """ 2D toy integrand that is a Gaussian on a circle
     """
-    return UserFunctionWrapper(_circular_gaussian), lambda x: _circular_gaussian(x, mean, variance)
+    2D toy integrand that is a Gaussian on a circle
+    """
+    func = lambda x: _circular_gaussian(x, mean, variance)
+    return UserFunctionWrapper(func), func
 
 
 def _circular_gaussian(x: np.ndarray, mean: np.float, variance: np.float):
     """
     :param x: (num_points, 2)
     :param mean: mean of Gaussian in radius (must be > 0)
+    :return: the function values at x, shape (num_points, 1)
     """
     norm_x = np.sqrt((x ** 2).sum(axis=1, keepdims=True))
     return norm_x**2 * np.exp(- (norm_x - mean)**2 / (2. * variance)) / np.sqrt(2. * np.pi * variance)

--- a/tests/emukit/quadrature/test_rbf_quadrature_kernel.py
+++ b/tests/emukit/quadrature/test_rbf_quadrature_kernel.py
@@ -1,0 +1,35 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import numpy as np
+import GPy
+
+from emukit.model_wrappers.gpy_quadrature_wrappers import RBFGPy
+from emukit.quadrature.kernels import QuadratureRBF
+
+
+def test_rbf_qkernel_shapes():
+    x1 = np.array([[-1, 1], [0, 0], [-2, 0.1]])
+    x2 = np.array([[-1, 1], [0, 0], [-2, 0.1], [-3, 3]])
+    M1 = x1.shape[0]
+    M2 = x2.shape[0]
+    D = x1.shape[1]
+
+    # integral bounds
+    lb = -3
+    ub = 3
+
+    gpy_kernel = GPy.kern.RBF(input_dim=D)
+    emukit_rbf = RBFGPy(gpy_kernel)
+    emukit_qrbf = QuadratureRBF(emukit_rbf, integral_bounds=D * [(lb, ub)])
+
+    # kernel shapes
+    assert emukit_qrbf.K(x1, x2).shape == (M1, M2)
+    assert emukit_qrbf.qK(x2).shape == (1, M2)
+    assert emukit_qrbf.Kq(x1).shape == (M1, 1)
+    assert isinstance(emukit_qrbf.qKq(), float)
+
+    # gradient shapes
+    assert emukit_qrbf.dKq_dx(x1).shape == (M1, D)
+    assert emukit_qrbf.dqK_dx(x2).shape == (D, M2)

--- a/tests/emukit/quadrature/test_vanilla_bq.py
+++ b/tests/emukit/quadrature/test_vanilla_bq.py
@@ -3,14 +3,17 @@
 
 
 import numpy as np
-import mock
 from numpy.testing import assert_array_equal
+import mock
+import GPy
 
 from emukit.quadrature.interfaces.base_gp import IBaseGaussianProcess
 from emukit.quadrature.methods.vanilla_bq import VanillaBayesianQuadrature
 from emukit.quadrature.kernels.integral_bounds import IntegralBounds
 from emukit.quadrature.kernels.quadrature_kernels import QuadratureKernel
+from emukit.quadrature.kernels import QuadratureRBF
 from emukit.core.continuous_parameter import ContinuousParameter
+from emukit.model_wrappers.gpy_quadrature_wrappers import RBFGPy, BaseGaussianProcessGPy
 
 
 def test_vanilla_bq_transformations():
@@ -44,3 +47,55 @@ def test_vanilla_bq_model():
     # the test is restrictive but easier to do than behavioral test when integral bounds are changed.
     assert method.integral_bounds == mock_bounds
     assert method.integral_parameters == 2 * [mock_cparam]
+
+
+def test_vanilla_bq_shapes():
+    X = np.array([[-1, 1], [0, 0], [-2, 0.1]])
+    Y = np.array([[1], [2], [3]])
+    x = np.array([[-1, 1], [0, 0], [-2, 0.1], [-3, 4]])
+    D = X.shape[1]
+
+    # integral bounds
+    lb = -3
+    ub = 3
+
+    gpy_model = GPy.models.GPRegression(X=X, Y=Y, kernel=GPy.kern.RBF(input_dim=D))
+    emukit_qrbf = QuadratureRBF(RBFGPy(gpy_model.kern), integral_bounds=D * [(lb, ub)])
+    emukit_model = BaseGaussianProcessGPy(kern=emukit_qrbf, gpy_model=gpy_model)
+    vanilla_bq = VanillaBayesianQuadrature(base_gp=emukit_model)
+
+    # integrate
+    res = vanilla_bq.integrate()
+    assert len(res) == 2
+    assert isinstance(res[0], float)
+    assert isinstance(res[1], float)
+
+    # transformations
+    assert vanilla_bq.transform(Y).shape == Y.shape
+    assert vanilla_bq.inverse_transform(Y).shape == Y.shape
+
+    # predictions base
+    res = vanilla_bq.predict_base(x)
+    assert len(res) == 4
+    for i in range(4):
+        assert res[i].shape == (x.shape[0], 1)
+
+    # predictions base full covariance
+    res = vanilla_bq.predict_base_with_full_covariance(x)
+    assert len(res) == 4
+    assert res[0].shape == (x.shape[0], 1)
+    assert res[1].shape == (x.shape[0], x.shape[0])
+    assert res[2].shape == (x.shape[0], 1)
+    assert res[3].shape == (x.shape[0], x.shape[0])
+
+    # predictions
+    res = vanilla_bq.predict(x)
+    assert len(res) == 2
+    assert res[0].shape == (x.shape[0], 1)
+    assert res[1].shape == (x.shape[0], 1)
+
+    # predictions full covariance
+    res = vanilla_bq.predict_with_full_covariance(x)
+    assert len(res) == 2
+    assert res[0].shape == (x.shape[0], 1)
+    assert res[1].shape == (x.shape[0], x.shape[0])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. a bug fix in circular_gaussian test function
2. integrate method of vanilla BQ returns tuple of two floats now instead of tuple of float and 1x1 array (I thought it did that before already...)
3. added shape and some type tests for quadrature kernel and integration model because of 2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
