### PR TITLE
batch prediction ; return var instead of std

### DIFF
--- a/emukit/examples/models/random_forest.py
+++ b/emukit/examples/models/random_forest.py
@@ -46,6 +46,7 @@ class RandomForest(IModel):
         Predict values for given points
 
         :param X: points to run prediction for
+        :return: Tuple of mean and variance which are 2d arrays of shape (n_points x n_outputs)
         """
 
         preds = []

--- a/emukit/examples/models/random_forest.py
+++ b/emukit/examples/models/random_forest.py
@@ -47,17 +47,13 @@ class RandomForest(IModel):
 
         :param X: points to run prediction for
         """
-        mean = np.zeros([X.shape[0], 1])
-        var = np.zeros([X.shape[0], 1])
 
-        for i, x in enumerate(X):
-            preds = []
-            for estimator in self.rf.estimators_:
-                pred = estimator.predict(x.reshape(1, -1))
-                preds.append(pred[0])
-            mean[i] = np.array(preds).mean()
-            var[i] = np.array(preds).std()
-
+        preds = []
+        for estimator in self.rf.estimators_:
+            pred = estimator.predict(X)
+            preds.append(pred)
+        mean = np.array(preds).mean(axis=0)[:, None]
+        var = np.array(preds).var(axis=0)[:, None]
         return mean, var
 
     def set_data(self, X: np.ndarray, Y: np.ndarray) -> None:


### PR DESCRIPTION
This PR fixes two problems of the random forest (RF):
 - At the moment the RF contains a python for loop to compute the prediction for each test point. However, sklearn allows to make batch prediction which is much more efficient.
 - Besides that, right now the RF returns the standard deviation instead of the variance.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
