### PR TITLE
Fix empty neighbourhood of local parameter, test this

### DIFF
--- a/emukit/core/optimization/local_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/local_search_acquisition_optimizer.py
@@ -93,7 +93,7 @@ class LocalSearchAcquisitionOptimizer(AcquisitionOptimizerBase):
                     this_neighbours.append([parameter.domain[current_index - 1]])
                 if current_index < len(parameter.domain) - 1:
                     this_neighbours.append([parameter.domain[current_index + 1]])
-                neighbours.append(np.asarray(this_neighbours))
+                neighbours.append(np.asarray(this_neighbours).reshape(-1, 1))
             elif isinstance(parameter, ContinuousParameter):
                 samples, param_range = [], parameter.max - parameter.min
                 while len(samples) < self.num_continuous:
@@ -120,8 +120,6 @@ class LocalSearchAcquisitionOptimizer(AcquisitionOptimizerBase):
         neighbours = np.full((num_neighbours, all_features.shape[0]), all_features)
         current_neighbour, current_feature = 0, 0
         for this_neighbours in neighbours_per_param:
-            if this_neighbours.size == 0:  # parameter has no neighbours
-                continue
             next_neighbour = current_neighbour + this_neighbours.shape[0]
             next_feature = current_feature + this_neighbours.shape[1]
             neighbours[current_neighbour:next_neighbour,

--- a/emukit/core/optimization/local_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/local_search_acquisition_optimizer.py
@@ -120,6 +120,8 @@ class LocalSearchAcquisitionOptimizer(AcquisitionOptimizerBase):
         neighbours = np.full((num_neighbours, all_features.shape[0]), all_features)
         current_neighbour, current_feature = 0, 0
         for this_neighbours in neighbours_per_param:
+            if this_neighbours.size == 0:  # parameter has no neighbours
+                continue
             next_neighbour = current_neighbour + this_neighbours.shape[0]
             next_feature = current_feature + this_neighbours.shape[1]
             neighbours[current_neighbour:next_neighbour,

--- a/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
@@ -57,8 +57,9 @@ def test_local_search_acquisition_optimizer_neighbours():
         DiscreteParameter('d', [0.1, 1.2, 2.3]),
         ContinuousParameter('e', 0, 100),
         DiscreteParameter('f', [0.1, 1.2, 2.3]),
+        DiscreteParameter('no_neighbours', [1]),
     ])
-    x = np.array([1, 0, 0, 1.6, 2.9, 0.1, 50, 1.2])
+    x = np.array([1, 0, 0, 1.6, 2.9, 0.1, 50, 1.2, 1.])
     optimizer = LocalSearchAcquisitionOptimizer(space, 1000, 3, num_continuous=1)
 
     neighbourhood = optimizer._neighbours_per_parameter(x, space.parameters)
@@ -68,16 +69,17 @@ def test_local_search_acquisition_optimizer_neighbours():
     assert_equal(np.array([[1.2]]), neighbourhood[3])
     assert_almost_equal(np.array([[53.5281047]]), neighbourhood[4])
     assert_equal(np.array([[0.1], [2.3]]), neighbourhood[5])
+    assert_equal(np.array([]), neighbourhood[6])
 
     neighbours = optimizer._neighbours(x, space.parameters)
     assert_almost_equal(np.array([
-        [0, 1, 0, 2., 3., 0.1, 50., 1.2],
-        [0, 0, 1, 2., 3., 0.1, 50., 1.2],
-        [1, 0, 0, 1., 3., 0.1, 50., 1.2],
-        [1, 0, 0, 3., 3., 0.1, 50., 1.2],
-        [1, 0, 0, 2., 2., 0.1, 50., 1.2],
-        [1, 0, 0, 2., 3., 1.2, 50., 1.2],
-        [1, 0, 0, 2., 3., 0.1, 50.80031442, 1.2],
-        [1, 0, 0, 2., 3., 0.1, 50., 0.1],
-        [1, 0, 0, 2., 3., 0.1, 50., 2.3],
+        [0, 1, 0, 2., 3., 0.1, 50., 1.2, 1.],
+        [0, 0, 1, 2., 3., 0.1, 50., 1.2, 1.],
+        [1, 0, 0, 1., 3., 0.1, 50., 1.2, 1.],
+        [1, 0, 0, 3., 3., 0.1, 50., 1.2, 1.],
+        [1, 0, 0, 2., 2., 0.1, 50., 1.2, 1.],
+        [1, 0, 0, 2., 3., 1.2, 50., 1.2, 1.],
+        [1, 0, 0, 2., 3., 0.1, 50.80031442, 1.2, 1.],
+        [1, 0, 0, 2., 3., 0.1, 50., 0.1, 1.],
+        [1, 0, 0, 2., 3., 0.1, 50., 2.3, 1.],
     ]), space.round(neighbours))

--- a/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
@@ -56,8 +56,8 @@ def test_local_search_acquisition_optimizer_neighbours():
         CategoricalParameter('c', OrdinalEncoding([0.1, 1, 2])),
         DiscreteParameter('d', [0.1, 1.2, 2.3]),
         ContinuousParameter('e', 0, 100),
-        DiscreteParameter('f', [0.1, 1.2, 2.3]),
         DiscreteParameter('no_neighbours', [1]),
+        DiscreteParameter('f', [0.1, 1.2, 2.3]),
     ])
     x = np.array([1, 0, 0, 1.6, 2.9, 0.1, 50, 1.2, 1.])
     optimizer = LocalSearchAcquisitionOptimizer(space, 1000, 3, num_continuous=1)
@@ -68,18 +68,18 @@ def test_local_search_acquisition_optimizer_neighbours():
     assert_equal(np.array([[2]]), neighbourhood[2])
     assert_equal(np.array([[1.2]]), neighbourhood[3])
     assert_almost_equal(np.array([[53.5281047]]), neighbourhood[4])
-    assert_equal(np.array([[0.1], [2.3]]), neighbourhood[5])
-    assert_equal(np.array([]), neighbourhood[6])
+    assert_equal(np.empty((0, 1)), neighbourhood[5])
+    assert_equal(np.array([[0.1], [2.3]]), neighbourhood[6])
 
     neighbours = optimizer._neighbours(x, space.parameters)
     assert_almost_equal(np.array([
-        [0, 1, 0, 2., 3., 0.1, 50., 1.2, 1.],
-        [0, 0, 1, 2., 3., 0.1, 50., 1.2, 1.],
-        [1, 0, 0, 1., 3., 0.1, 50., 1.2, 1.],
-        [1, 0, 0, 3., 3., 0.1, 50., 1.2, 1.],
-        [1, 0, 0, 2., 2., 0.1, 50., 1.2, 1.],
-        [1, 0, 0, 2., 3., 1.2, 50., 1.2, 1.],
-        [1, 0, 0, 2., 3., 0.1, 50.80031442, 1.2, 1.],
-        [1, 0, 0, 2., 3., 0.1, 50., 0.1, 1.],
-        [1, 0, 0, 2., 3., 0.1, 50., 2.3, 1.],
+        [0, 1, 0, 2., 3., 0.1, 50., 1., 1.2],
+        [0, 0, 1, 2., 3., 0.1, 50., 1., 1.2],
+        [1, 0, 0, 1., 3., 0.1, 50., 1., 1.2],
+        [1, 0, 0, 3., 3., 0.1, 50., 1., 1.2],
+        [1, 0, 0, 2., 2., 0.1, 50., 1., 1.2],
+        [1, 0, 0, 2., 3., 1.2, 50., 1., 1.2],
+        [1, 0, 0, 2., 3., 0.1, 50.80031442, 1., 1.2],
+        [1, 0, 0, 2., 3., 0.1, 50., 1., 0.1],
+        [1, 0, 0, 2., 3., 0.1, 50., 1., 2.3],
     ]), space.round(neighbours))


### PR DESCRIPTION
*Description of changes:*

Handle the edge case of empty neighbourhood of a discrete parameter.
The other parameters already handled it correctly. 
Occurs rarely in practice, but should not throw an error. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
