### PR TITLE
Feature: Information Source Encoding Types

### DIFF
--- a/emukit/bayesian_optimization/acquisitions/entropy_search.py
+++ b/emukit/bayesian_optimization/acquisitions/entropy_search.py
@@ -7,7 +7,7 @@ from typing import Union, Callable
 import scipy
 import numpy as np
 
-from ...core import InformationSourceParameter
+from ...core import InformationSourceParameter, DiscreteInformationSourceParameter, OrdinalInformationSourceParameter
 from ...core.acquisition import Acquisition
 from ...core.interfaces import IModel
 from ...core.parameter_space import ParameterSpace
@@ -240,8 +240,13 @@ class MultiInformationSourceEntropySearch(EntropySearch):
 
         # Assume we are in a multi-fidelity setting and the highest index is the highest fidelity
         if target_information_source_index is None:
-            target_information_source_index = max(info_source_parameter.domain)
-        self.target_information_source_index = target_information_source_index
+            if isinstance(info_source_parameter, (DiscreteInformationSourceParameter,
+                                                  OrdinalInformationSourceParameter)):
+                self.target_information_source_index = info_source_parameter.bounds[0][1]
+            else:
+                raise ValueError('target_information_index is None and cannot automatically determined.')
+        else:
+            self.target_information_source_index = target_information_source_index
 
         # Sampler of representer points should sample x location at the target information source only so make a
         # parameter space without the information source parameter

--- a/emukit/core/__init__.py
+++ b/emukit/core/__init__.py
@@ -3,7 +3,8 @@
 
 from .categorical_parameter import CategoricalParameter  # noqa: F401
 from .continuous_parameter import ContinuousParameter  # noqa: F401
-from .discrete_parameter import DiscreteParameter, InformationSourceParameter  # noqa: F401
+from .discrete_parameter import DiscreteParameter  # noqa: F401
 from .encodings import OneHotEncoding, OrdinalEncoding  # noqa: F401
+from .information_source_parameter import *  # noqa: F401, F403
 from .parameter import Parameter  # noqa: F401
 from .parameter_space import ParameterSpace  # noqa: F401

--- a/emukit/core/discrete_parameter.py
+++ b/emukit/core/discrete_parameter.py
@@ -69,11 +69,3 @@ class DiscreteParameter(Parameter):
             x_rounded.append([rounded_value])
 
         return np.row_stack(x_rounded)
-
-
-class InformationSourceParameter(DiscreteParameter):
-    def __init__(self, n_sources: int) -> None:
-        """
-        :param n_sources: Number of information sources in the problem
-        """
-        super().__init__('source', list(range(n_sources)))

--- a/emukit/core/information_source_parameter.py
+++ b/emukit/core/information_source_parameter.py
@@ -1,0 +1,104 @@
+import abc
+from typing import Iterable
+
+import numpy as np
+
+from . import CategoricalParameter, DiscreteParameter
+from . import OneHotEncoding, OrdinalEncoding
+from .parameter import Parameter
+
+
+class InformationSourceParameter(abc.ABC, Parameter):
+    @abc.abstractmethod
+    def source_indices(self, values: np.ndarray) -> np.ndarray:
+        """ Calculate the indices corresponding to the parameter values.
+
+        :param values: Parameter values as (num points, num features)
+        :return: 1d-array of the source indices
+        """
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def encodings(self) -> np.ndarray:
+        """ Source encodings as 2d-array (points, features). """
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def n_sources(self) -> int:
+        """ Number of sources. """
+        raise NotImplementedError
+
+
+
+class NominalInformationSourceParameter(CategoricalParameter, InformationSourceParameter):
+    def __init__(self, n_sources: int) -> None:
+        """ Information source parameter on nominal scale.
+
+        Useful if only equality relation is valid (e.g. no ordering).
+        E.g. information sources correspond to datasets.
+
+        Parameter values are categorical and one-hot encoded.
+
+        :param n_sources: Number of information sources in the problem
+        """
+        CategoricalParameter.__init__(self, 'source', OneHotEncoding(list(range(n_sources))))
+
+    def source_indices(self, values: np.ndarray) -> np.ndarray:
+        """ See InformationSourceParameter.source_indices """
+        return np.asarray([self.encoding.get_category(row) for row in self.round(values)])
+
+    @property
+    def n_sources(self) -> int:
+        """ Number of sources. """
+        return self.encodings.shape[0]
+
+
+class OrdinalInformationSourceParameter(CategoricalParameter, InformationSourceParameter):
+    def __init__(self, n_sources: int) -> None:
+        """ Information source parameter on ordinal scale.
+
+        Useful if only equality and order relation is valid (e.g. no ratio).
+        E.g. information sou'source', OneHotEncoding(list(range(n_sources)))rces correspond to multi-fidelity.
+
+        Parameter values are categorical and ordinal encoded.
+
+        :param n_sources: Number of information sources in the problem
+        """
+        CategoricalParameter.__init__(self, 'source', OrdinalEncoding(list(range(n_sources))))
+
+    def source_indices(self, values: np.ndarray) -> np.ndarray:
+        """ See InformationSourceParameter.source_indices """
+        return np.asarray([self.encoding.get_category(row) for row in self.round(values)])
+
+    @property
+    def n_sources(self) -> int:
+        """ Number of sources. """
+        return self.encodings.shape[0]
+
+
+class DiscreteInformationSourceParameter(DiscreteParameter, InformationSourceParameter):
+    def __init__(self, sources: Iterable[int]) -> None:
+        """ Discrete information source parameter.
+
+        E.g. information sources correspond to multi-fidelity
+        where the fidelity steps are not uniform.
+
+        :param sources: Encoding values of information sources in the problem
+        """
+        DiscreteParameter.__init__(self, 'source', list(sources))
+
+    def source_indices(self, values: np.ndarray) -> np.ndarray:
+        """ See InformationSourceParameter.source_indices """
+        return np.where(self.round(values) == np.asarray(self.domain))[1]
+
+    @property
+    def encodings(self) -> np.ndarray:
+        """ Source encodings as 2d-array (points, features). """
+        return np.asarray(self.domain).reshape(-1, 1)
+
+    @property
+    def n_sources(self) -> int:
+        """ Number of sources. """
+        return len(self.domain)

--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -27,7 +27,7 @@ class AcquisitionOptimizerBase(abc.ABC):
 
             # Log warning if context parameter is out of domain
             param = self.space.get_parameter_by_name(context_name)
-            if param.check_in_domain(context_value) is False:
+            if param.check_in_domain(np.asarray(context_value).reshape(1, -1)) is False:
                 _log.warning(context_name + ' with value ' + str(context_value), ' is out of the domain')
             else:
                 _log.info('Parameter ' + context_name + ' fixed to ' + str(context_value))

--- a/emukit/core/optimization/multi_source_acquisition_optimizer.py
+++ b/emukit/core/optimization/multi_source_acquisition_optimizer.py
@@ -26,7 +26,7 @@ class MultiSourceAcquisitionOptimizer(AcquisitionOptimizerBase):
         self.acquisition_optimizer = acquisition_optimizer
         self.space = space
         self.source_parameter = self._get_information_source_parameter()
-        self.n_sources = np.array(self.source_parameter.domain).size
+        self.n_sources = self.source_parameter.n_sources
 
     def _get_information_source_parameter(self) -> InformationSourceParameter:
         """
@@ -58,7 +58,7 @@ class MultiSourceAcquisitionOptimizer(AcquisitionOptimizerBase):
                         the parameter name and the value is the value to fix the parameter to.
         :return: A tuple of (location of maximum, acquisition value at maximum)
         """
-        f_maxs = np.zeros((len(self.source_parameter.domain)))
+        f_maxs = np.zeros((self.source_parameter.n_sources, self.source_parameter.dimension))
         x_opts = []
 
         if context is None:
@@ -68,11 +68,12 @@ class MultiSourceAcquisitionOptimizer(AcquisitionOptimizerBase):
             return self.acquisition_optimizer.optimize(acquisition, context)
 
         # Optimize acquisition for each information source
-        for i in range(len(self.source_parameter.domain)):
+        for i, source_encoding in enumerate(self.source_parameter.encodings):
             # Fix the source using a dictionary, the key is the name of the parameter to fix and the value is the
             # value to which the parameter is fixed
-            context[self.source_parameter.name] = self.source_parameter.domain[i]
+            context[self.source_parameter.name] = source_encoding
             x, f_maxs[i] = self.acquisition_optimizer.optimize(acquisition, context)
             x_opts.append(x)
         best_source = np.argmax(f_maxs)
+        print(f_maxs)
         return x_opts[best_source], np.max(f_maxs)

--- a/emukit/core/parameter_space.py
+++ b/emukit/core/parameter_space.py
@@ -7,9 +7,7 @@ import numpy as np
 import GPyOpt
 
 from .parameter import Parameter
-from . import CategoricalParameter
-from . import ContinuousParameter
-from .discrete_parameter import DiscreteParameter, InformationSourceParameter
+from . import CategoricalParameter, ContinuousParameter, DiscreteParameter, InformationSourceParameter
 
 
 class ParameterSpace(object):
@@ -111,8 +109,11 @@ class ParameterSpace(object):
                                 'dimensionality': 1}
                 gpyopt_parameters.append(gpyopt_param)
             elif isinstance(parameter, CategoricalParameter):
+                name = parameter.name
                 for i, cat_sub_param in enumerate(parameter.model_parameters):
-                    gpyopt_param = {'name': parameter.name + '_' + str(i),
+                    if len(parameter.model_parameters) > 1:
+                        name = parameter.name + '_' + str(i)
+                    gpyopt_param = {'name': name,
                                     'type': 'continuous',
                                     'domain': (cat_sub_param.min, cat_sub_param.max),
                                     'dimensionality': 1}

--- a/emukit/test_functions/forrester.py
+++ b/emukit/test_functions/forrester.py
@@ -29,7 +29,7 @@ def multi_fidelity_forrester_function(high_fidelity_noise_std_deviation=0, low_f
     parameter_space = ParameterSpace([ContinuousParameter('x', 0, 1), OrdinalInformationSourceParameter(2)])
     user_function = MultiSourceFunctionWrapper([
         lambda x: forrester_low(x, low_fidelity_noise_std_deviation),
-        lambda x: forrester(x, high_fidelity_noise_std_deviation)])
+        lambda x: forrester(x, high_fidelity_noise_std_deviation)], parameter_space.parameters[-1].encodings)
     return user_function, parameter_space
 
 

--- a/emukit/test_functions/forrester.py
+++ b/emukit/test_functions/forrester.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from emukit.core import ParameterSpace, ContinuousParameter, InformationSourceParameter
+from emukit.core import ParameterSpace, ContinuousParameter, OrdinalInformationSourceParameter
 from emukit.core.loop.user_function import MultiSourceFunctionWrapper
 
 
@@ -26,7 +26,7 @@ def multi_fidelity_forrester_function(high_fidelity_noise_std_deviation=0, low_f
                                              Defaults to zero.
     :return: Tuple of user function object and parameter space object
     """
-    parameter_space = ParameterSpace([ContinuousParameter('x', 0, 1), InformationSourceParameter(2)])
+    parameter_space = ParameterSpace([ContinuousParameter('x', 0, 1), OrdinalInformationSourceParameter(2)])
     user_function = MultiSourceFunctionWrapper([
         lambda x: forrester_low(x, low_fidelity_noise_std_deviation),
         lambda x: forrester(x, high_fidelity_noise_std_deviation)])

--- a/emukit/test_functions/multi_fidelity/borehole.py
+++ b/emukit/test_functions/multi_fidelity/borehole.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import numpy as np
 
-from ...core import ContinuousParameter, InformationSourceParameter, ParameterSpace
+from ...core import ContinuousParameter, OrdinalInformationSourceParameter, ParameterSpace
 from ...core.loop.user_function import MultiSourceFunctionWrapper
 
 
@@ -34,11 +34,11 @@ def multi_fidelity_borehole_function(high_noise_std_deviation: float = 0, low_no
         ContinuousParameter('lower_aquifer_head', 700, 820),
         ContinuousParameter('borehole_length', 1120, 1680),
         ContinuousParameter('hydraulic_conductivity', 9855, 12045),
-        InformationSourceParameter(2)])
+        OrdinalInformationSourceParameter(2)])
 
     user_function = MultiSourceFunctionWrapper([
         lambda x: _borehole_low(x, low_noise_std_deviation),
-        lambda x: _borehole_high(x, high_noise_std_deviation)])
+        lambda x: _borehole_high(x, high_noise_std_deviation)], parameter_space.parameters[-1].encodings)
 
     return user_function, parameter_space
 

--- a/emukit/test_functions/multi_fidelity/branin.py
+++ b/emukit/test_functions/multi_fidelity/branin.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import numpy as np
 
 from ..branin import _branin
-from ...core import ParameterSpace, ContinuousParameter, InformationSourceParameter
+from ...core import ParameterSpace, ContinuousParameter, OrdinalInformationSourceParameter
 from ...core.loop.user_function import MultiSourceFunctionWrapper
 
 
@@ -57,9 +57,7 @@ def multi_fidelity_branin_function() -> Tuple[MultiSourceFunctionWrapper, Parame
         return result[:, None]
 
     parameter_space = ParameterSpace([ContinuousParameter('x1', -5, 10), ContinuousParameter('x2', 0, 15),
-                                      InformationSourceParameter(3)])
+                                      OrdinalInformationSourceParameter(3)])
 
-    return MultiSourceFunctionWrapper([branin_low_fidelity, branin_medium_fidelity, _branin]), parameter_space
-
-
-
+    return (MultiSourceFunctionWrapper([branin_low_fidelity, branin_medium_fidelity, _branin],
+                                       parameter_space.parameters[-1].encodings), parameter_space)

--- a/emukit/test_functions/multi_fidelity/currin.py
+++ b/emukit/test_functions/multi_fidelity/currin.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import numpy as np
 
 from ...core.loop.user_function import MultiSourceFunctionWrapper
-from ...core import ContinuousParameter, InformationSourceParameter, ParameterSpace
+from ...core import ContinuousParameter, OrdinalInformationSourceParameter, ParameterSpace
 
 
 def multi_fidelity_currin_function() -> Tuple[MultiSourceFunctionWrapper, ParameterSpace]:
@@ -41,5 +41,5 @@ def multi_fidelity_currin_function() -> Tuple[MultiSourceFunctionWrapper, Parame
                 0.25 * high(np.stack([x[:, 0] - 0.05, np.maximum(0, x[:, 1] - 0.05)], axis=1)))
 
     space = ParameterSpace([ContinuousParameter('x1', 0, 1), ContinuousParameter('x2', 0, 1),
-                            InformationSourceParameter(2)])
-    return MultiSourceFunctionWrapper([low, high]), space
+                            OrdinalInformationSourceParameter(2)])
+    return MultiSourceFunctionWrapper([low, high], space.parameters[-1].encodings), space

--- a/emukit/test_functions/multi_fidelity/hartmann.py
+++ b/emukit/test_functions/multi_fidelity/hartmann.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import numpy as np
 
 from ...core.loop.user_function import MultiSourceFunctionWrapper
-from ...core import ParameterSpace, ContinuousParameter, InformationSourceParameter
+from ...core import ParameterSpace, ContinuousParameter, OrdinalInformationSourceParameter
 
 
 def multi_fidelity_hartmann_3d() -> Tuple[MultiSourceFunctionWrapper, ParameterSpace]:
@@ -99,8 +99,8 @@ def multi_fidelity_hartmann_3d() -> Tuple[MultiSourceFunctionWrapper, ParameterS
         return res[:, None]
 
     space = ParameterSpace([ContinuousParameter('x1', 0., 1.), ContinuousParameter('x2', 0., 1.),
-                            ContinuousParameter('x3', 0., 1.), InformationSourceParameter(3)])
+                            ContinuousParameter('x3', 0., 1.), OrdinalInformationSourceParameter(3)])
 
-    fcn_wrapper = MultiSourceFunctionWrapper([low, medium, high])
+    fcn_wrapper = MultiSourceFunctionWrapper([low, medium, high], space.parameters[-1].encodings)
 
     return fcn_wrapper, space

--- a/emukit/test_functions/multi_fidelity/park.py
+++ b/emukit/test_functions/multi_fidelity/park.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import numpy as np
 
 from ...core.loop.user_function import MultiSourceFunctionWrapper
-from ...core import ContinuousParameter, InformationSourceParameter, ParameterSpace
+from ...core import ContinuousParameter, OrdinalInformationSourceParameter, ParameterSpace
 
 
 def multi_fidelity_park_function() -> Tuple[MultiSourceFunctionWrapper, ParameterSpace]:
@@ -49,6 +49,6 @@ def multi_fidelity_park_function() -> Tuple[MultiSourceFunctionWrapper, Paramete
 
     space = ParameterSpace([ContinuousParameter('x1', 0., 1.), ContinuousParameter('x2', 0., 1.),
                             ContinuousParameter('x3', 0., 1.), ContinuousParameter('x4', 0., 1.),
-                            InformationSourceParameter(2)])
+                            OrdinalInformationSourceParameter(2)])
 
-    return MultiSourceFunctionWrapper([park_low, park_high]), space
+    return MultiSourceFunctionWrapper([park_low, park_high], space.parameters[-1].encodings), space

--- a/emukit/test_functions/non_linear_sin.py
+++ b/emukit/test_functions/non_linear_sin.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from emukit.core import ParameterSpace, ContinuousParameter, InformationSourceParameter
+from emukit.core import ParameterSpace, ContinuousParameter, OrdinalInformationSourceParameter
 from emukit.core.loop.user_function import MultiSourceFunctionWrapper
 
 
@@ -22,7 +22,7 @@ def multi_fidelity_non_linear_sin(high_fidelity_noise_std_deviation=0, low_fidel
     http://web.mit.edu/parisp/www/assets/20160751.full.pdf
     """
 
-    parameter_space = ParameterSpace([ContinuousParameter('x1', -5, 10), InformationSourceParameter(2)])
+    parameter_space = ParameterSpace([ContinuousParameter('x1', -5, 10), OrdinalInformationSourceParameter(2)])
     user_function = MultiSourceFunctionWrapper([
         lambda x: nonlinear_sin_low(x, low_fidelity_noise_std_deviation),
         lambda x: nonlinear_sin_high(x, high_fidelity_noise_std_deviation)])

--- a/emukit/test_functions/non_linear_sin.py
+++ b/emukit/test_functions/non_linear_sin.py
@@ -25,7 +25,7 @@ def multi_fidelity_non_linear_sin(high_fidelity_noise_std_deviation=0, low_fidel
     parameter_space = ParameterSpace([ContinuousParameter('x1', -5, 10), OrdinalInformationSourceParameter(2)])
     user_function = MultiSourceFunctionWrapper([
         lambda x: nonlinear_sin_low(x, low_fidelity_noise_std_deviation),
-        lambda x: nonlinear_sin_high(x, high_fidelity_noise_std_deviation)])
+        lambda x: nonlinear_sin_high(x, high_fidelity_noise_std_deviation)], parameter_space.parameters[-1].encodings)
     return user_function, parameter_space
 
 

--- a/notebooks/Emukit-tutorial-multi-fidelity-bayesian-optimization.ipynb
+++ b/notebooks/Emukit-tutorial-multi-fidelity-bayesian-optimization.ipynb
@@ -118,10 +118,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from emukit.core import ParameterSpace, ContinuousParameter, InformationSourceParameter\n",
+    "from emukit.core import ParameterSpace, ContinuousParameter, OrdinalInformationSourceParameter\n",
     "n_fidelities = 2\n",
     "\n",
-    "parameter_space = ParameterSpace([ContinuousParameter('x', 0, 1), InformationSourceParameter(n_fidelities)])"
+    "parameter_space = ParameterSpace([ContinuousParameter('x', 0, 1), OrdinalInformationSourceParameter(n_fidelities)])"
    ]
   },
   {

--- a/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_equal
 from numpy.testing import assert_almost_equal
 
 from emukit.core import CategoricalParameter, ContinuousParameter
-from emukit.core import DiscreteParameter, InformationSourceParameter
+from emukit.core import DiscreteParameter, OrdinalInformationSourceParameter
 from emukit.core import OneHotEncoding, OrdinalEncoding
 from emukit.core import ParameterSpace, Parameter
 from emukit.core.encodings import Encoding
@@ -39,7 +39,7 @@ def test_local_search_acquisition_optimizer(simple_square_acquisition):
 
 def test_local_search_acquisition_optimizer_with_context(simple_square_acquisition):
     space = ParameterSpace([CategoricalParameter('x', OrdinalEncoding(np.arange(0, 100))),
-                            InformationSourceParameter(10)])
+                            OrdinalInformationSourceParameter(10)])
     optimizer = LocalSearchAcquisitionOptimizer(space, 1000, 3)
 
     source_encoding = 1

--- a/tests/emukit/core/optimization/test_multi_source_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_multi_source_acquisition_optimizer.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from emukit.core import ContinuousParameter
-from emukit.core import InformationSourceParameter
+from emukit.core import OrdinalInformationSourceParameter
 from emukit.core import ParameterSpace
 from emukit.core.optimization import GradientAcquisitionOptimizer
 from emukit.core.optimization import MultiSourceAcquisitionOptimizer
@@ -10,10 +10,10 @@ from emukit.core.optimization import MultiSourceAcquisitionOptimizer
 
 def test_multi_source_acquisition_optimizer(simple_square_acquisition):
     space = ParameterSpace([ContinuousParameter('x', 0, 1),
-                            InformationSourceParameter(2)])
+                            OrdinalInformationSourceParameter(2)])
     single_optimizer = GradientAcquisitionOptimizer(space)
     optimizer = MultiSourceAcquisitionOptimizer(single_optimizer, space)
 
     opt_x, opt_val = optimizer.optimize(simple_square_acquisition)
-    assert_array_equal(opt_x, np.array([[0., 1.]]))
-    assert_array_equal(opt_val, np.array([[2.]]))
+    assert_array_equal(opt_x, np.array([[0., 2.]]))
+    assert_array_equal(opt_val, np.array([[3.]]))

--- a/tests/emukit/core/optimization/test_random_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_random_search_acquisition_optimizer.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from emukit.core import CategoricalParameter
-from emukit.core import InformationSourceParameter
+from emukit.core import OrdinalInformationSourceParameter
 from emukit.core import OrdinalEncoding
 from emukit.core import ParameterSpace
 from emukit.core.optimization import RandomSearchAcquisitionOptimizer
@@ -20,7 +20,7 @@ def test_random_search_acquisition_optimizer(simple_square_acquisition):
 
 def test_random_search_acquisition_optimizer_with_context(simple_square_acquisition):
     space = ParameterSpace([CategoricalParameter('x', OrdinalEncoding(np.arange(0, 100))),
-                            InformationSourceParameter(10)])
+                            OrdinalInformationSourceParameter(10)])
     optimizer = RandomSearchAcquisitionOptimizer(space, 1000)
 
     source_encoding = 1

--- a/tests/emukit/core/test_multi_source_optimizer.py
+++ b/tests/emukit/core/test_multi_source_optimizer.py
@@ -2,7 +2,7 @@ import mock
 import numpy as np
 import pytest
 
-from emukit.core import ContinuousParameter, InformationSourceParameter, ParameterSpace
+from emukit.core import ContinuousParameter, OrdinalInformationSourceParameter, ParameterSpace
 from emukit.core.acquisition import Acquisition
 from emukit.core.loop import LoopState, SequentialPointCalculator
 from emukit.core.optimization import GradientAcquisitionOptimizer
@@ -13,7 +13,7 @@ from emukit.core.optimization.multi_source_acquisition_optimizer import MultiSou
 def multi_source_optimizer():
     mock_acquisition_optimizer = mock.create_autospec(GradientAcquisitionOptimizer)
     mock_acquisition_optimizer.optimize.return_value = (np.array([[0.]]), None)
-    space = ParameterSpace([ContinuousParameter('x', 0, 1), InformationSourceParameter(2)])
+    space = ParameterSpace([ContinuousParameter('x', 0, 1), OrdinalInformationSourceParameter(2)])
     return MultiSourceAcquisitionOptimizer(mock_acquisition_optimizer, space)
 
 
@@ -47,7 +47,7 @@ def test_multi_source_sequential_with_context():
     mock_acquisition.evaluate = lambda x: np.sum(x**2, axis=1)[:, None]
     space = ParameterSpace([ContinuousParameter('x', 0, 1),
                             ContinuousParameter('y', 0, 1),
-                            InformationSourceParameter(2)])
+                            OrdinalInformationSourceParameter(2)])
     acquisition_optimizer = GradientAcquisitionOptimizer(space)
     multi_source_acquisition_optimizer = MultiSourceAcquisitionOptimizer(acquisition_optimizer, space)
 
@@ -68,7 +68,7 @@ def test_multi_source_sequential_with_source_context():
     mock_acquisition.evaluate = lambda x: np.sum(x**2, axis=1)[:, None]
     space = ParameterSpace([ContinuousParameter('x', 0, 1),
                             ContinuousParameter('y', 0, 1),
-                            InformationSourceParameter(2)])
+                            OrdinalInformationSourceParameter(2)])
     acquisition_optimizer = GradientAcquisitionOptimizer(space)
     multi_source_acquisition_optimizer = MultiSourceAcquisitionOptimizer(acquisition_optimizer, space)
 

--- a/tests/emukit/core/test_parameter_space.py
+++ b/tests/emukit/core/test_parameter_space.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from emukit.core import ContinuousParameter, ParameterSpace, InformationSourceParameter, DiscreteParameter, \
+from emukit.core import ContinuousParameter, ParameterSpace, OrdinalInformationSourceParameter, DiscreteParameter, \
     CategoricalParameter, OneHotEncoding
 
 
@@ -43,7 +43,7 @@ def test_check_in_domain_fails(space_2d):
 
 def test_two_information_source_parameters_fail():
     with pytest.raises(ValueError):
-        ParameterSpace([InformationSourceParameter(2), InformationSourceParameter(2)])
+        ParameterSpace([OrdinalInformationSourceParameter(2), OrdinalInformationSourceParameter(2)])
 
 
 def test_get_parameter_by_name(space_2d):

--- a/tests/emukit/core/test_parameters.py
+++ b/tests/emukit/core/test_parameters.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from emukit.core import ContinuousParameter
-from emukit.core import DiscreteParameter, InformationSourceParameter
+from emukit.core import DiscreteParameter, DiscreteInformationSourceParameter
+from emukit.core import NominalInformationSourceParameter, OrdinalInformationSourceParameter
 
 
 def test_continuous_parameter():
@@ -43,14 +44,26 @@ def test_single_value_in_domain_discrete_parameter():
 
 
 def test_information_source_parameter():
-    param = InformationSourceParameter(5)
+    param = NominalInformationSourceParameter(3)
     assert param.name == 'source'
-    assert param.check_in_domain(np.array([0, 1])) is True
-    assert param.check_in_domain(np.array([4])) is True
-    assert param.check_in_domain(np.array([5])) is False
+    assert param.check_in_domain(np.array([[0, 1, 0]])) is True
+    assert param.check_in_domain(np.array([[1, 0, 0]])) is True
+    assert param.check_in_domain(np.array([[5, 5, 5]])) is False
+
+    param = OrdinalInformationSourceParameter(5)
+    assert param.name == 'source'
+    assert param.check_in_domain(np.array([[1], [2]])) is True
+    assert param.check_in_domain(np.array([[3]])) is True
+    assert param.check_in_domain(np.array([[6]])) is False
+
+    param = DiscreteInformationSourceParameter([0.1, 0.3, 0.9])
+    assert param.name == 'source'
+    assert param.check_in_domain(np.array([[0.1], [0.9]])) is True
+    assert param.check_in_domain(np.array([0.3])) is True
+    assert param.check_in_domain(np.array([[5]])) is False
 
 
 def test_single_value_in_domain_information_source_parameter():
-    param = InformationSourceParameter(5)
+    param = DiscreteInformationSourceParameter(range(0, 5))
     assert param.check_in_domain(2) is True
     assert param.check_in_domain(7) is False

--- a/tests/emukit/core/test_user_function.py
+++ b/tests/emukit/core/test_user_function.py
@@ -60,8 +60,9 @@ def test_user_function_wrapper_invalid_input():
 def test_multi_source_function_wrapper_evaluation_no_cost():
     functions = [lambda x: 2 * x, lambda x: 4 * x]
     function_input = np.array([[1, 0], [2, 1], [3, 0], [4, 0], [5, 1]])
+    source_encodings = np.array([[0], [1]])
     source_index = -1
-    msfw = MultiSourceFunctionWrapper(functions, source_index)
+    msfw = MultiSourceFunctionWrapper(functions, source_encodings, source_index)
 
     output = msfw.evaluate(function_input)
 
@@ -78,8 +79,9 @@ def test_multi_source_function_wrapper_evaluation_with_cost():
     functions = [lambda x: (2 * x, np.array([[1]] * x.shape[0])),
                  lambda x: (4 * x, np.array([[2]] * x.shape[0]))]
     function_input = np.array([[1, 0], [2, 1], [3, 0], [4, 0], [5, 1]])
+    source_encodings = np.array([[0], [1]])
     source_index = -1
-    msfw = MultiSourceFunctionWrapper(functions, source_index)
+    msfw = MultiSourceFunctionWrapper(functions, source_encodings, source_index)
 
     output = msfw.evaluate(function_input)
 
@@ -93,25 +95,27 @@ def test_multi_source_function_wrapper_evaluation_with_cost():
 
 
 def test_multi_source_function_wrapper_invalid_input():
+    source_encodings = np.array([[0]])
+
     # invalid input
     with pytest.raises(ValueError):
         functions = [lambda x: 2 * x]
         function_input = np.array([1, 0])
-        msfw = MultiSourceFunctionWrapper(functions)
+        msfw = MultiSourceFunctionWrapper(functions, source_encodings)
         msfw.evaluate(function_input)
 
     # invalid function output
     with pytest.raises(ValueError):
         functions = [lambda x: np.array([2])]
         function_input = np.array([[1, 0]])
-        msfw = MultiSourceFunctionWrapper(functions)
+        msfw = MultiSourceFunctionWrapper(functions, source_encodings)
         msfw.evaluate(function_input)
 
     # invalid function output type
     with pytest.raises(ValueError):
         functions = [lambda x: [2]]
         function_input = np.array([[1, 0]])
-        msfw = MultiSourceFunctionWrapper(functions)
+        msfw = MultiSourceFunctionWrapper(functions, source_encodings)
         msfw.evaluate(function_input)
 
 

--- a/tests/emukit/test_acquisitions.py
+++ b/tests/emukit/test_acquisitions.py
@@ -10,7 +10,7 @@ from emukit.bayesian_optimization.acquisitions import ExpectedImprovement, Negat
 from emukit.bayesian_optimization.acquisitions import IntegratedExpectedImprovement
 from emukit.bayesian_optimization.acquisitions.entropy_search import MultiInformationSourceEntropySearch
 from emukit.bayesian_optimization.acquisitions.log_acquisition import LogAcquisition
-from emukit.core import ParameterSpace, ContinuousParameter, InformationSourceParameter
+from emukit.core import ParameterSpace, ContinuousParameter, OrdinalInformationSourceParameter
 from emukit.core.acquisition.acquisition_per_cost import CostAcquisition
 
 from emukit.bayesian_optimization.acquisitions import ProbabilityOfImprovement
@@ -95,7 +95,7 @@ def squared_correlation_acquisition(vanilla_bq_model):
 @pytest.fixture
 @pytest.mark.parametrize('n_dims', [2])
 def multi_source_entropy_search_acquisition(gpy_model):
-    space = ParameterSpace([ContinuousParameter('x1', 0, 1), InformationSourceParameter(2)])
+    space = ParameterSpace([ContinuousParameter('x1', 0, 1), OrdinalInformationSourceParameter(2)])
     return MultiInformationSourceEntropySearch(gpy_model, space, num_representer_points=10)
 
 

--- a/tests/emukit/test_functions/test_multi_fidelity_functions.py
+++ b/tests/emukit/test_functions/test_multi_fidelity_functions.py
@@ -16,14 +16,15 @@ def test_multi_fidelity_function_shapes(fcn):
     samples = random.get_samples(n_points)
 
     # There are only 2 or 3 fidelity functions in set of functions we are testing
-    n_fidelities = len(space.parameters[-1].domain)
+    n_fidelities = space.parameters[-1].n_sources
+    source_encodings = space.parameters[-1].encodings
     if n_fidelities == 2:
-        samples[:5, -1] = 0
-        samples[5:, -1] = 1
+        samples[:5, -1] = source_encodings[0]
+        samples[5:, -1] = source_encodings[1]
     elif n_fidelities == 3:
-        samples[:5, -1] = 0
-        samples[5:8, -1] = 1
-        samples[8:, -1] = 2
+        samples[:5, -1] = source_encodings[0]
+        samples[5:8, -1] = source_encodings[1]
+        samples[8:, -1] = source_encodings[2]
     else:
         raise ValueError('Please add a case for functions with {:.0f} fidelity levels'.format(n_fidelities))
 


### PR DESCRIPTION
Currently information sources are always represented as special discrete parameters.
This is might be appropriate e.g. for most multi-fidelity use cases.
When information sources are not ordered (e.g. multiple dataset) it might not be desired to encode them as (0, 1, 2, ...). This encoding is used to train the model, but some models might infer dataset 0 is more similar to dataset 1 than to dataset 2. 
Therefore this PR proposes to separate encoding and source indices of information source parameters.

*Description of changes:*

* Add ordinal, normal and discrete information source parameters
* Separate source encoding and indices in multisource userfunction and multi source optimizer 
* Fix userfunction, notebook and tests appropriately

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
