### PR TITLE
fix to regenerate sample used for entropy search at each optimization step

### DIFF
--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -80,7 +80,11 @@ class OuterLoop(object):
 
         while not stopping_condition.should_stop(self.loop_state):
             _log.info("Iteration {}".format(self.loop_state.iteration))
-
+            # Entropy search acquisition requires resampling at each step
+            try:
+                self.candidate_point_calculator.acquisition.update_parameters()
+            except:
+                pass
             self._update_models()
             new_x = self.candidate_point_calculator.compute_next_points(self.loop_state, context)
             results = user_function.evaluate(new_x)


### PR DESCRIPTION
Issue 210

If using the entropy search acquisition function, then this needs to be regenerated for each step in the optimization. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
