### PR TITLE
Remove implicit import of LatinDesign

### DIFF
--- a/emukit/examples/multi_fidelity_dgp/benchmarking_examples.ipynb
+++ b/emukit/examples/multi_fidelity_dgp/benchmarking_examples.ipynb
@@ -28,7 +28,7 @@
     "from emukit.examples.multi_fidelity_dgp.baseline_model_wrappers import LinearAutoRegressiveModel, NonLinearAutoRegressiveModel, HighFidelityGp\n",
     "\n",
     "from emukit.core import ContinuousParameter\n",
-    "from emukit.experimental_design import LatinDesign\n",
+    "from emukit.experimental_design.model_free.latin_design import LatinDesign\n",
     "from emukit.examples.multi_fidelity_dgp.multi_fidelity_deep_gp import MultiFidelityDeepGP\n",
     "\n",
     "from emukit.test_functions.multi_fidelity import (multi_fidelity_borehole_function, multi_fidelity_branin_function,\n",

--- a/emukit/experimental_design/__init__.py
+++ b/emukit/experimental_design/__init__.py
@@ -2,5 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from .model_free.latin_design import LatinDesign  # noqa: F401
 from .model_free.random_design import RandomDesign  # noqa: F401

--- a/integration_tests/emukit/experimental_design/test_experimental_design_with_categorical.py
+++ b/integration_tests/emukit/experimental_design/test_experimental_design_with_categorical.py
@@ -4,7 +4,7 @@ import numpy as np
 from emukit.core import ParameterSpace, ContinuousParameter, CategoricalParameter, OneHotEncoding
 
 from emukit.experimental_design.model_based.experimental_design_loop import ExperimentalDesignLoop
-from emukit.experimental_design import LatinDesign
+from emukit.experimental_design.model_free.latin_design import LatinDesign
 from emukit.model_wrappers import GPyModelWrapper
 
 

--- a/tests/emukit/experimental_design/test_model_free_designs.py
+++ b/tests/emukit/experimental_design/test_model_free_designs.py
@@ -1,5 +1,6 @@
 from emukit.core import CategoricalParameter, ContinuousParameter, DiscreteParameter, ParameterSpace
-from emukit.experimental_design import LatinDesign, RandomDesign
+from emukit.experimental_design import RandomDesign
+from emukit.experimental_design.model_free.latin_design import LatinDesign
 
 
 def create_model_free_designs(space: ParameterSpace):


### PR DESCRIPTION
*Issue #, if available:* #214 

*Description of changes:* Since LatinDesign carries some additional dependencies, i propose we remove implicit import of it from experimental_design package. This way it can never be imported accidentally. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
