### PR TITLE
fix bug in interface of single_objective_bayesian_optimisation example

### DIFF
--- a/emukit/examples/gp_bayesian_optimization/single_objective_bayesian_optimization.py
+++ b/emukit/examples/gp_bayesian_optimization/single_objective_bayesian_optimization.py
@@ -89,7 +89,7 @@ class GPBayesianOptimization(BayesianOptimizationLoop):
 
     def suggest_new_locations(self):
         """ Returns one or a batch of locations without evaluating the objective """
-        return self.candidate_point_calculator.compute_next_points(self.loop_state)[0].X
+        return self.candidate_point_calculator.compute_next_points(self.loop_state)[0]
 
     def run_optimization(self, user_function: UserFunction, num_iterations: int) -> None:
         """

--- a/integration_tests/emukit/bayesian_optimization/test_single_objective_bayesian_optimization.py
+++ b/integration_tests/emukit/bayesian_optimization/test_single_objective_bayesian_optimization.py
@@ -19,3 +19,4 @@ def test_loop():
 
     # Check we got the correct number of points
     assert bo.loop_state.X.shape[0] == n_iterations + 5
+    assert bo.suggest_new_locations().shape == (1,)


### PR DESCRIPTION
*Description of changes:*

single_objective_bayesian_optimisation.py, used within the tutorial examples, seems to have a call to an attribute that no longer exists (perhaps part of old interface?). Removing that call appears to lead to the desired behaviour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
