### PR TITLE
Remove libomp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
     - pyenv
     - openssl
     - readline
-    - libomp
     update: true
 before_install: |
  if [[ $TRAVIS_OS_NAME == 'osx' ]]; then


### PR DESCRIPTION
*Issue #, if available:* #199 

*Description of changes:* libomp was added because of a pytorch bug that now seems to be fixed. This PR removes the install.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
