### PR TITLE
Added control over MCMC parameters when calling the integrated acquisition

### DIFF
--- a/emukit/core/acquisition/integrated_acquisition.py
+++ b/emukit/core/acquisition/integrated_acquisition.py
@@ -10,16 +10,20 @@ class IntegratedHyperParameterAcquisition(Acquisition):
     """
     This acquisition class provides functionality for integrating any acquisition function over model hyper-parameters
     """
-    def __init__(self, model: Union[IModel, IPriorHyperparameters], acquisition_generator: Callable, n_samples: int=10,n_burnin: int=100, subsample_interval: int=10,step_size: float=1e-1,leapfrog_steps: int=20):
+    def __init__(self, model: Union[IModel, IPriorHyperparameters], acquisition_generator: Callable, n_samples: int=10, n_burnin: int=100, subsample_interval: int=10, step_size: float=1e-1, leapfrog_steps: int=20):
         """
         :param model: An emukit model that implements IPriorHyperparameters
         :param acquisition_generator: Function that returns acquisition object when given the model as the only argument
         :param n_samples: Number of hyper-parameter samples
+        :param n_burnin: Number of initial samples not used.
+        :param subsample_interval: Interval of subsampling from HMC samples.
+        :param step_size: Size of the gradient steps in the HMC sampler.
+        :param leapfrog_steps: Number of gradient steps before each Metropolis Hasting step.
         """
         self.model = model
         self.acquisition_generator = acquisition_generator
         self.n_samples = n_samples
-        self.samples = self.model.generate_hyperparameters_samples(n_samples,n_burnin,subsample_interval,step_size,leapfrog_steps)
+        self.samples = self.model.generate_hyperparameters_samples(n_samples, n_burnin, subsample_interval, step_size, leapfrog_steps)
 
     def evaluate(self, x: np.ndarray) -> np.ndarray:
         """

--- a/emukit/core/acquisition/integrated_acquisition.py
+++ b/emukit/core/acquisition/integrated_acquisition.py
@@ -10,7 +10,7 @@ class IntegratedHyperParameterAcquisition(Acquisition):
     """
     This acquisition class provides functionality for integrating any acquisition function over model hyper-parameters
     """
-    def __init__(self, model: Union[IModel, IPriorHyperparameters], acquisition_generator: Callable, n_samples: int=10):
+    def __init__(self, model: Union[IModel, IPriorHyperparameters], acquisition_generator: Callable, n_samples: int=10,n_burnin: int=100, subsample_interval: int=10,step_size: float=1e-1,leapfrog_steps: int=20):
         """
         :param model: An emukit model that implements IPriorHyperparameters
         :param acquisition_generator: Function that returns acquisition object when given the model as the only argument
@@ -19,7 +19,7 @@ class IntegratedHyperParameterAcquisition(Acquisition):
         self.model = model
         self.acquisition_generator = acquisition_generator
         self.n_samples = n_samples
-        self.samples = self.model.generate_hyperparameters_samples(n_samples)
+        self.samples = self.model.generate_hyperparameters_samples(n_samples,n_burnin,subsample_interval,step_size,leapfrog_steps)
 
     def evaluate(self, x: np.ndarray) -> np.ndarray:
         """


### PR DESCRIPTION

#236

Functionality to control all the MCMC parameters when defining an integrated acquisition function. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
