### PR TITLE
Fix to feed raw (non-transformed) s to the model/acquisition

### DIFF
--- a/emukit/examples/fabolas/fabolas_loop.py
+++ b/emukit/examples/fabolas/fabolas_loop.py
@@ -39,7 +39,7 @@ class FabolasLoop(CostSensitiveBayesianOptimizationLoop):
         """
 
         l = space.parameters
-        l.extend([ContinuousParameter("s", np.log(s_min), np.log(s_max))])  # optimize s on a log scale
+        l.extend([ContinuousParameter("s", s_min, s_max)])  
         extended_space = ParameterSpace(l)
 
         model_objective = FabolasModel(X_init=X_init, Y_init=Y_init, s_min=s_min, s_max=s_max)


### PR DESCRIPTION
Fabolas currently transforms the fidelity space to a log scale, however, the fabolas model/acquisitions are expecting the fidelity pre-transform.

I have discussed this fix with @aaronkl 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
