### PR TITLE
Typo fix in instructions how to contribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ See installing from source.
 ### Running tests
 Run the full suite of tests by running:
 ```
-python -m pytests
+python -m pytest
 ```
 from the top level directory. This also does coverage checks.
 


### PR DESCRIPTION
Updated the module name from pytests to pytest.

*Issue #, if available:*
-
*Description of changes:*
changed module name pytests to pytest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
