### PR TITLE
version bug fix

### DIFF
--- a/emukit/__init__.py
+++ b/emukit/__init__.py
@@ -1,2 +1,4 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from emukit.__version__ import __version__


### PR DESCRIPTION
 Issue #251

Can now see version number like standard python package using


`import emukit`
`emukit.__version__`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
