### PR TITLE
Boolean operations for stopping conditions

### DIFF
--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -61,7 +61,8 @@ class OuterLoop(object):
         :param user_function: The function that we are emulating
         :param stopping_condition: If integer - a number of iterations to run, or an object - a stopping
                         condition object that decides whether we should stop collecting more points.
-                        Note that stopping conditions can be logically combined to represent complex stopping criteria.
+                        Note that stopping conditions can be logically combined (&, |)
+                        to represent complex stopping criteria.
         :param context: The context is used to force certain parameters of the inputs to the function of interest to
                         have a given value. It is a dictionary whose keys are the parameter names to fix and the values
                         are the values to fix the parameters to.
@@ -71,7 +72,7 @@ class OuterLoop(object):
         is_single_condition = isinstance(stopping_condition, StoppingCondition)
 
         if not (is_int or is_single_condition):
-            raise ValueError("Expected stopping_condition to be an int or a single StoppingCondition instance,"
+            raise ValueError("Expected stopping_condition to be an int or a StoppingCondition instance,"
                              "but received {}".format(type(stopping_condition)))
 
         if not isinstance(user_function, UserFunction):

--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -55,13 +55,13 @@ class OuterLoop(object):
         self.iteration_end_event = EventHandler()
 
     def run_loop(self, user_function: Union[UserFunction, Callable],
-                 stopping_condition: Union[StoppingCondition, int, List[StoppingCondition]],
+                 stopping_condition: Union[StoppingCondition, int],
                  context: dict = None) -> None:
         """
         :param user_function: The function that we are emulating
-        :param stopping_condition: If integer - a number of iterations to run, or an object (or list of such objects) - a stopping
-                        condition object that decides whether we should stop collecting more points. When input is a list,
-                        we stop when any of the conditions are violated.
+        :param stopping_condition: If integer - a number of iterations to run, or an object - a stopping
+                        condition object that decides whether we should stop collecting more points.
+                        Note that stopping conditions can be logically combined to represent complex stopping criteria.
         :param context: The context is used to force certain parameters of the inputs to the function of interest to
                         have a given value. It is a dictionary whose keys are the parameter names to fix and the values
                         are the values to fix the parameters to.
@@ -69,11 +69,9 @@ class OuterLoop(object):
 
         is_int = isinstance(stopping_condition, int)
         is_single_condition = isinstance(stopping_condition, StoppingCondition)
-        is_list_of_conditions = (isinstance(stopping_condition, list)
-                                 and all([isinstance(condition, StoppingCondition) for condition in stopping_condition]))
 
-        if not (is_int or is_single_condition or is_list_of_conditions):
-            raise ValueError("Expected stopping_condition to be an int or a single/list of StoppingCondition instance(s),"
+        if not (is_int or is_single_condition):
+            raise ValueError("Expected stopping_condition to be an int or a single StoppingCondition instance,"
                              "but received {}".format(type(stopping_condition)))
 
         if not isinstance(user_function, UserFunction):
@@ -82,14 +80,11 @@ class OuterLoop(object):
         if isinstance(stopping_condition, int):
             stopping_condition = FixedIterationsStoppingCondition(stopping_condition + self.loop_state.iteration)
 
-        if isinstance(stopping_condition, StoppingCondition):
-            stopping_condition = [stopping_condition]
-
         _log.info("Starting outer loop")
 
         self.loop_start_event(self, self.loop_state)
 
-        while not any([condition.should_stop(self.loop_state)for condition in stopping_condition]):
+        while not stopping_condition.should_stop(self.loop_state):
             _log.info("Iteration {}".format(self.loop_state.iteration))
 
             self._update_models()

--- a/emukit/core/loop/stopping_conditions.py
+++ b/emukit/core/loop/stopping_conditions.py
@@ -14,6 +14,19 @@ _log = logging.getLogger(__name__)
 
 class StoppingCondition(abc.ABC):
     """ Chooses whether to stop the optimization based on the loop state """
+
+    def __and__(self, other: 'StoppingCondition') -> 'And':
+        """
+        Overloads self & other
+        """
+        return And(self, other)
+
+    def __or__(self, other: 'StoppingCondition') -> 'Or':
+        """
+        Overloads self | other
+        """
+        return Or(self, other)
+
     @abc.abstractmethod
     def should_stop(self, loop_state: LoopState) -> bool:
         """
@@ -21,6 +34,50 @@ class StoppingCondition(abc.ABC):
         :return: Whether to stop collecting new data
         """
         pass
+
+
+class And(StoppingCondition):
+    """
+    Logical AND of two stopping conditions
+    """
+    def __init__(self, left: StoppingCondition, right: StoppingCondition):
+        """
+        :param left: One stopping condition in AND
+        :param right: Another stopping condition in AND
+        """
+        self.left = left
+        self.right = right
+
+    def should_stop(self, loop_state: LoopState) -> bool:
+        """
+        Evaluate logical AND of two stopping conditions
+
+        :param loop_state: Object that contains current state of the loop
+        :return: Whether to stop collecting new data
+        """
+        return self.left.should_stop(loop_state) and self.right.should_stop(loop_state)
+
+
+class Or(StoppingCondition):
+    """
+    Logical OR of two stopping conditions
+    """
+    def __init__(self, left: StoppingCondition, right: StoppingCondition):
+        """
+        :param left: One stopping condition in OR
+        :param right: Another stopping condition in OR
+        """
+        self.left = left
+        self.right = right
+
+    def should_stop(self, loop_state: LoopState) -> bool:
+        """
+        Evaluate logical OR of two stopping conditions
+
+        :param loop_state: Object that contains current state of the loop
+        :return: Whether to stop collecting new data
+        """
+        return self.left.should_stop(loop_state) or self.right.should_stop(loop_state)
 
 
 class FixedIterationsStoppingCondition(StoppingCondition):

--- a/notebooks/Emukit-tutorial-basic-use-of-the-library.ipynb
+++ b/notebooks/Emukit-tutorial-basic-use-of-the-library.ipynb
@@ -236,25 +236,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimization restart 1/1, f = 120.4143743517718\n",
-      "Optimization restart 1/1, f = 126.98158917847543\n",
-      "Optimization restart 1/1, f = 131.5249140489932\n",
-      "Optimization restart 1/1, f = 116.83114850755967\n",
-      "Optimization restart 1/1, f = 136.04023661578782\n",
-      "Optimization restart 1/1, f = 132.9762653978784\n",
-      "Optimization restart 1/1, f = 117.02045902721012\n",
-      "Optimization restart 1/1, f = 98.46824905735313\n",
-      "Optimization restart 1/1, f = 92.96380712138502\n",
-      "Optimization restart 1/1, f = 101.81482995351502\n",
-      "Optimization restart 1/1, f = 86.25555757756555\n"
+      "Optimization restart 1/1, f = 120.91026677911276\n",
+      "Optimization restart 1/1, f = 126.38888372911657\n",
+      "Optimization restart 1/1, f = 128.57539289869513\n",
+      "Optimization restart 1/1, f = 145.66133277971716\n",
+      "Optimization restart 1/1, f = 113.64152836723314\n"
      ]
     }
    ],
    "source": [
     "# Run the loop and extract the optimum\n",
     "# Run the loop until we make 10 steps or converge\n",
-    "stopping_condition = [FixedIterationsStoppingCondition(i_max = 10),\n",
-    "                      ConvergenceStoppingCondition(eps=0.01)]\n",
+    "stopping_condition = FixedIterationsStoppingCondition(i_max = 10) | ConvergenceStoppingCondition(eps=0.01)\n",
     "\n",
     "bayesopt_loop.run_loop(f, stopping_condition)"
    ]
@@ -308,17 +301,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimization restart 1/1, f = 86.25555757756555\n",
-      "Optimization restart 1/1, f = 100.21070540830769\n",
-      "Optimization restart 1/1, f = 110.50017728474651\n",
-      "Optimization restart 1/1, f = 112.51353438248088\n",
-      "Optimization restart 1/1, f = 110.50807217598556\n",
-      "Optimization restart 1/1, f = 113.1614227828\n",
-      "Optimization restart 1/1, f = 111.91461367832788\n",
-      "Optimization restart 1/1, f = 108.55938600958443\n",
-      "Optimization restart 1/1, f = 112.98400581401714\n",
-      "Optimization restart 1/1, f = 101.7662951859583\n",
-      "Optimization restart 1/1, f = 97.14534716069412\n"
+      "Optimization restart 1/1, f = 113.64152836723314\n",
+      "Optimization restart 1/1, f = 149.18447353966997\n",
+      "Optimization restart 1/1, f = 165.18858190045052\n",
+      "Optimization restart 1/1, f = 177.24506767903355\n",
+      "Optimization restart 1/1, f = 185.5084733679322\n",
+      "Optimization restart 1/1, f = 203.19511155408117\n",
+      "Optimization restart 1/1, f = 209.59556586940982\n",
+      "Optimization restart 1/1, f = 212.33410143813973\n",
+      "Optimization restart 1/1, f = 212.17902574652348\n",
+      "Optimization restart 1/1, f = 209.45273845806753\n",
+      "Optimization restart 1/1, f = 206.30152892093886\n"
      ]
     }
    ],
@@ -434,7 +427,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/tests/emukit/core/test_loop_steps.py
+++ b/tests/emukit/core/test_loop_steps.py
@@ -6,82 +6,9 @@ from emukit.core.acquisition import Acquisition
 from emukit.core.interfaces import IModel
 from emukit.core.loop import (FixedIntervalUpdater,
                               FixedIterationsStoppingCondition, LoopState,
-                              SequentialPointCalculator,
-                              UserFunctionWrapper, RandomSampling,
-                              ConvergenceStoppingCondition)
+                              RandomSampling, SequentialPointCalculator,
+                              UserFunctionWrapper)
 from emukit.core.optimization import GradientAcquisitionOptimizer
-
-
-def test_fixed_iteration_stopping_condition():
-    stopping_condition = FixedIterationsStoppingCondition(5)
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 0
-
-    assert(stopping_condition.should_stop(loop_state_mock) is False)
-
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 5
-
-    assert(stopping_condition.should_stop(loop_state_mock) is True)
-
-
-def test_convergence_stopping_condition():
-    stopping_condition = ConvergenceStoppingCondition(0.1)
-
-    # check if we stop before criterion can be calculated
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 1
-    loop_state_mock.X = np.array([[0]])
-    assert(stopping_condition.should_stop(loop_state_mock) is False)
-
-    # check if we stop when we should not
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 5
-    loop_state_mock.X = np.array([[0], [10], [20], [30], [40]])
-    assert(stopping_condition.should_stop(loop_state_mock) is False)
-
-    # check if we stop when we should
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 5
-    loop_state_mock.X.return_value(np.array([[0], [1], [2], [3], [3.01]]))
-    assert(stopping_condition.should_stop(loop_state_mock) is True)
-
-
-def test_list_of_stopping_conditions():
-    
-
-    # check if we stop when neither criterion triggered
-    m = mock.Mock()
-    m.side_effect = [ConvergenceStoppingCondition(0.1), FixedIterationsStoppingCondition(5)]
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 3
-    loop_state_mock.X = np.array([[0], [10], [20]])
-    assert(m().should_stop(loop_state_mock) is False)
-    assert(m().should_stop(loop_state_mock)is False)
-
-    # check if we stop when we should due to criterion 1
-    m.side_effect = [ConvergenceStoppingCondition(0.1), FixedIterationsStoppingCondition(5)]
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 3
-    loop_state_mock.X = np.array([[0], [1], [1.01]])
-    assert(m().should_stop(loop_state_mock) is True)
-    assert(m().should_stop(loop_state_mock) is False)
-
-    # check if we stop when we should due to criterion 2
-    m.side_effect = [ConvergenceStoppingCondition(0.1), FixedIterationsStoppingCondition(5)]
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 6
-    loop_state_mock.X = np.array([[0], [10], [20], [30], [40], [50]])
-    assert(m().should_stop(loop_state_mock) is False)
-    assert(m().should_stop(loop_state_mock) is True)
-
-    # check if we stop when we should due to both criteria
-    m.side_effect = [ConvergenceStoppingCondition(0.1), FixedIterationsStoppingCondition(5)]
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 6
-    loop_state_mock.X = np.array([[0], [10], [20], [30], [40], [40.01]])
-    assert(m().should_stop(loop_state_mock) is True)
-    assert(m().should_stop(loop_state_mock) is True)
 
 
 def test_every_iteration_model_updater():

--- a/tests/emukit/core/test_stopping_conditions.py
+++ b/tests/emukit/core/test_stopping_conditions.py
@@ -13,15 +13,18 @@ class DummyStoppingCondition(StoppingCondition):
 
 
 def test_fixed_iteration_stopping_condition():
-    stopping_condition = FixedIterationsStoppingCondition(5)
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 0
+    n_iterations = 5
 
+    stopping_condition = FixedIterationsStoppingCondition(n_iterations)
+    loop_state_mock = mock.create_autospec(LoopState)
+
+    loop_state_mock.iteration = 0
     assert(stopping_condition.should_stop(loop_state_mock) is False)
 
-    loop_state_mock = mock.create_autospec(LoopState)
-    loop_state_mock.iteration = 5
+    loop_state_mock.iteration = n_iterations - 1
+    assert(stopping_condition.should_stop(loop_state_mock) is False)
 
+    loop_state_mock.iteration = n_iterations
     assert(stopping_condition.should_stop(loop_state_mock) is True)
 
 

--- a/tests/emukit/core/test_stopping_conditions.py
+++ b/tests/emukit/core/test_stopping_conditions.py
@@ -1,0 +1,81 @@
+import numpy as np
+import mock
+
+from emukit.core.loop import (ConvergenceStoppingCondition,
+                              FixedIterationsStoppingCondition,
+                              LoopState,
+                              StoppingCondition)
+
+
+class DummyStoppingCondition(StoppingCondition):
+    def should_stop(self, loop_state: LoopState) -> bool:
+        pass
+
+
+def test_fixed_iteration_stopping_condition():
+    stopping_condition = FixedIterationsStoppingCondition(5)
+    loop_state_mock = mock.create_autospec(LoopState)
+    loop_state_mock.iteration = 0
+
+    assert(stopping_condition.should_stop(loop_state_mock) is False)
+
+    loop_state_mock = mock.create_autospec(LoopState)
+    loop_state_mock.iteration = 5
+
+    assert(stopping_condition.should_stop(loop_state_mock) is True)
+
+
+def test_convergence_stopping_condition():
+    stopping_condition = ConvergenceStoppingCondition(0.1)
+
+    # check if we stop before criterion can be calculated
+    loop_state_mock = mock.create_autospec(LoopState)
+    loop_state_mock.iteration = 1
+    loop_state_mock.X = np.array([[0]])
+    assert(stopping_condition.should_stop(loop_state_mock) is False)
+
+    # check if we stop when we should not
+    loop_state_mock = mock.create_autospec(LoopState)
+    loop_state_mock.iteration = 5
+    loop_state_mock.X = np.array([[0], [10], [20], [30], [40]])
+    assert(stopping_condition.should_stop(loop_state_mock) is False)
+
+    # check if we stop when we should
+    loop_state_mock = mock.create_autospec(LoopState)
+    loop_state_mock.iteration = 5
+    loop_state_mock.X.return_value(np.array([[0], [1], [2], [3], [3.01]]))
+    assert(stopping_condition.should_stop(loop_state_mock) is True)
+
+
+def test_operations_with_conditions():
+    left_condition = DummyStoppingCondition()
+    right_condition = DummyStoppingCondition()
+    mock_loop_state = mock.create_autospec(LoopState)
+
+    or_condition = left_condition | right_condition
+    and_condition = left_condition & right_condition
+
+    left_condition.should_stop = mock.MagicMock(return_value=True)
+    right_condition.should_stop = mock.MagicMock(return_value=True)
+    assert(or_condition.should_stop(mock_loop_state) is True)
+    assert(and_condition.should_stop(mock_loop_state) is True)
+
+    left_condition.should_stop = mock.MagicMock(return_value=True)
+    right_condition.should_stop = mock.MagicMock(return_value=False)
+    assert(or_condition.should_stop(mock_loop_state) is True)
+    assert(and_condition.should_stop(mock_loop_state) is False)
+
+    left_condition.should_stop = mock.MagicMock(return_value=False)
+    right_condition.should_stop = mock.MagicMock(return_value=True)
+    assert(or_condition.should_stop(mock_loop_state) is True)
+    assert(and_condition.should_stop(mock_loop_state) is False)
+
+    left_condition.should_stop = mock.MagicMock(return_value=False)
+    right_condition.should_stop = mock.MagicMock(return_value=False)
+    assert(or_condition.should_stop(mock_loop_state) is False)
+    assert(and_condition.should_stop(mock_loop_state) is False)
+
+    complex_combination = (left_condition | right_condition) & left_condition
+    left_condition.should_stop = mock.MagicMock(return_value=False)
+    right_condition.should_stop = mock.MagicMock(return_value=True)
+    assert(complex_combination.should_stop(mock_loop_state) is False)


### PR DESCRIPTION
*Issue #, if available:* #273 

*Description of changes:* This implements logical operations on stopping conditions. Namely, we can now combine them with `&` (and) and `|` (or). Sadly, Python's `and` and `or` cannot be overloaded.

This also makes ability to accept a list of conditions in the loop redundant, so this option is removed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
