### PR TITLE
Default values for some optimizers

### DIFF
--- a/emukit/core/optimization/local_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/local_search_acquisition_optimizer.py
@@ -46,7 +46,7 @@ class LocalSearchAcquisitionOptimizer(AcquisitionOptimizerBase):
            International Conference on Learning and Intelligent Optimization.
            Springer, Berlin, Heidelberg, 2011.
     """
-    def __init__(self, space: ParameterSpace, num_steps: int, num_init_points: int,
+    def __init__(self, space: ParameterSpace, num_steps: int = 10, num_init_points: int = 5,
                  std_dev: float = 0.02, num_continuous: int = 4) -> None:
         """
         :param space: The parameter space spanning the search problem.

--- a/emukit/core/optimization/random_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/random_search_acquisition_optimizer.py
@@ -15,10 +15,11 @@ _log = logging.getLogger(__name__)
 
 
 class RandomSearchAcquisitionOptimizer(AcquisitionOptimizerBase):
-    """ Optimizes the acquisition function by evaluating at random points.
+    """
+    Optimizes the acquisition function by evaluating at random points.
     Can be used for discrete and continuous acquisition functions.
     """
-    def __init__(self, space: ParameterSpace, num_eval_points: int) -> None:
+    def __init__(self, space: ParameterSpace, num_eval_points: int = 10) -> None:
         """
         :param space: The parameter space spanning the search problem.
         :param num_eval_points: Number of random sampled points which are evaluated per optimization.


### PR DESCRIPTION
*Issue #, if available:* #235 

*Description of changes:* to pick these numbers I've just looked at other optimization codes, and it seems that most of the time people just use 5 or 10 as reasonably small defaults.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
