### PR TITLE
removed unused matplotlib and SequentialPointCalculator logic

### DIFF
--- a/notebooks/Emukit-tutorial-basic-use-of-the-library.ipynb
+++ b/notebooks/Emukit-tutorial-basic-use-of-the-library.ipynb
@@ -22,17 +22,7 @@
    "source": [
     "# General imports and parameters of figures should be loaded at the beginning of the overview\n",
     "\n",
-    "# General imports\n",
-    "%matplotlib inline\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "from matplotlib import colors as mcolors\n",
-    "\n",
-    "# Figure config\n",
-    "colors = dict(mcolors.BASE_COLORS, **mcolors.CSS4_COLORS)\n",
-    "LEGEND_SIZE = 15\n",
-    "TITLE_SIZE = 25\n",
-    "AXIS_SIZE = 15"
+    "import numpy as np\n"
    ]
   },
   {
@@ -185,9 +175,6 @@
     "from emukit.core.loop import FixedIterationsStoppingCondition\n",
     "from emukit.core.loop import ConvergenceStoppingCondition\n",
     "\n",
-    "# Point calculator\n",
-    "from emukit.core.loop import SequentialPointCalculator\n",
-    "\n",
     "# Bayesian quadrature kernel and model\n",
     "from emukit.quadrature.kernels import QuadratureRBFLebesgueMeasure\n",
     "from emukit.quadrature.methods import VanillaBayesianQuadrature"
@@ -210,8 +197,7 @@
    "source": [
     "# Load core elements for Bayesian optimization\n",
     "expected_improvement = ExpectedImprovement(model = model_emukit)\n",
-    "optimizer            = GradientAcquisitionOptimizer(space = parameter_space)\n",
-    "point_calculator     = SequentialPointCalculator(expected_improvement, optimizer)"
+    "optimizer            = GradientAcquisitionOptimizer(space = parameter_space)\n"
    ]
   },
   {
@@ -274,8 +260,7 @@
    "source": [
     "# Load core elements for Experimental design\n",
     "model_variance   = ModelVariance(model = model_emukit)\n",
-    "optimizer        = GradientAcquisitionOptimizer(space = parameter_space)\n",
-    "point_calculator = SequentialPointCalculator(model_variance, optimizer)"
+    "optimizer        = GradientAcquisitionOptimizer(space = parameter_space)\n"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
- matplotlib imports and configuration at head of tutorial were misleading - all plotting preparation went unused in this notebook.
- SeqeuntialPointCalculator import and instantiation as `point_calculator` was misleading - it went unused vis a vis the OuterLoop BayesianOptimizationLoop instantiated with `acquisition` and `model`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.