### PR TITLE
Allow context={} in OuterLoop.get_next_points()

### DIFF
--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -103,10 +103,7 @@ class OuterLoop(object):
         for model_updater in self.model_updaters:
             model_updater.update(self.loop_state)
 
-    def get_next_points(self,
-        results: List[UserFunctionResult],
-        context: dict={}
-        ) -> np.ndarray:
+    def get_next_points(self, results: List[UserFunctionResult], context: dict={}) -> np.ndarray:
         """
         This method is used when the user doesn't want Emukit to evaluate the function of interest but rather just wants
         the input locations to evaluate the function at. This method calculates the new input locations.

--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -103,15 +103,21 @@ class OuterLoop(object):
         for model_updater in self.model_updaters:
             model_updater.update(self.loop_state)
 
-    def get_next_points(self, results: List[UserFunctionResult]) -> np.ndarray:
+    def get_next_points(self,
+        results: List[UserFunctionResult],
+        context: dict={}
+        ) -> np.ndarray:
         """
         This method is used when the user doesn't want Emukit to evaluate the function of interest but rather just wants
         the input locations to evaluate the function at. This method calculates the new input locations.
 
         :param results: Function results since last loop step
+        :param context: A dictionary of fixed parameters, identical to the context used in
+                        self.run_loop()
         :return: Next batch of points to run
         """
         if results:
             self.loop_state.update(results)
             self._update_models()
-        return self.candidate_point_calculator.compute_next_points(self.loop_state)
+        new_x = self.candidate_point_calculator.compute_next_points(self.loop_state, context)
+        return new_x


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
added context: dict={} as kwarg to OuterLoop.get_next_points() for the external evaluation mode

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
