### PR TITLE
UserFunction(abc.ABC) -> UserFunction(abc.ABC, Callable)

### DIFF
--- a/emukit/core/loop/user_function.py
+++ b/emukit/core/loop/user_function.py
@@ -26,6 +26,7 @@ class UserFunction(abc.ABC, Callable):
     @abc.abstractmethod
     def evaluate(self, X: np.ndarray) -> List[UserFunctionResult]:
         pass
+
     def __call__(self, X: np.ndarray) -> List[UserFunctionResult]:
         return self.evaluate(X)
 

--- a/emukit/core/loop/user_function.py
+++ b/emukit/core/loop/user_function.py
@@ -21,11 +21,13 @@ import logging
 _log = logging.getLogger(__name__)
 
 
-class UserFunction(abc.ABC):
+class UserFunction(abc.ABC, Callable):
     """ The user supplied function is interrogated as part of the outer loop """
     @abc.abstractmethod
     def evaluate(self, X: np.ndarray) -> List[UserFunctionResult]:
         pass
+    def __call__(self, X: np.ndarray) -> List[UserFunctionResult]:
+        return self.evaluate(X)
 
 
 class UserFunctionWrapper(UserFunction):

--- a/emukit/core/loop/user_function_result.py
+++ b/emukit/core/loop/user_function_result.py
@@ -30,6 +30,13 @@ class UserFunctionResult(object):
         self.X = X
         self.Y = Y
 
+    def __eq__(self, other):
+        is_eq = False
+        try:
+            is_eq = all(self.X == other.X) and all(self.Y == other.Y) and self.extra_outputs == other.extra_outputs
+        finally:
+            return is_eq
+
     def __getattr__(self, item):
         """
         Allow extra output values to be accessed as an attribute

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,6 @@
 This folder contains unit tests for core Emukit functionality.
+
+The tests have extra requirements. To install them, execute:
+`pip install -r requirements/test_requirements.txt`
+
+To run tests, from the root directory, execute `python -m pytest`

--- a/tests/emukit/core/test_user_function.py
+++ b/tests/emukit/core/test_user_function.py
@@ -19,6 +19,17 @@ def test_user_function_wrapper_evaluation_single_output():
         assert_array_equal(output[i].Y, function(function_input[i]))
 
 
+def test_user_function_wrapper_callable_single_output():
+    function = lambda x: 2 * x
+    function_input = np.array([[1], [2], [3]])
+    ufw = UserFunctionWrapper(function)
+
+    evaluated_output = ufw.evaluate(function_input)
+    called_output = ufw(function_input)
+    assert len(evaluated_output) == len(called_output)
+    assert all(eo == co for (eo, co) in zip(evaluated_output, called_output))
+
+
 def test_user_function_wrapper_evaluation_with_cost():
     function = lambda x: (2 * x, np.array([[1]] * x.shape[0]))
     function_input = np.array([[1], [2], [3]])


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
On top of the context-in-OuterLoop::get_next_points() PR, this implements the Callable mixin for UserFunction. It means you can do `user_function(x)` in addition to `user_function.evaluate(x)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
