### PR TITLE
Change mcmc_sampler to be compatible with emcee 2x and 3x

### DIFF
--- a/emukit/samplers/mcmc_sampler.py
+++ b/emukit/samplers/mcmc_sampler.py
@@ -55,10 +55,14 @@ class AffineInvariantEnsembleSampler(McmcSampler):
         sampler = emcee.EnsembleSampler(n_samples, X_init.shape[1], log_p_function)
 
         # Burn-In
-        samples, samples_log, _ = sampler.run_mcmc(X_init, burn_in_steps)
+        state = list(sampler.run_mcmc(X_init, burn_in_steps)) # compatible with both emcee 2 and 3
+        samples = state[0]
+        samples_log = state[1]
 
         # MCMC Sampling
-        samples, samples_log, _ = sampler.run_mcmc(samples, n_steps)
+        state = list(sampler.run_mcmc(samples, n_steps))
+        samples = state[0]
+        samples_log = state[1]
 
         # make sure we have an array of shape (n samples, space input dim)
         if len(samples.shape) == 1:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.14.5
 # but until GPy and GPyOpt get their dependencies straight
 # we need GPy's plotting extra to ensure smooth installation
 GPy[plotting]>=1.9.9
-emcee==2.2.1
-scipy==1.1.0
+emcee>=2.2.1
+scipy>=1.1.0


### PR DESCRIPTION
*Issue #, if available:* #295

*Description of changes:* See PR https://github.com/amzn/emukit/pull/299 which highlighted the issue. MCMC output format has changed in emcee>3; now it returns a State rather than a list. State is backwards compatible with a list. Hence the code change that works with both.

*To test with two emcee versions:*

```
# suppose your global emcee version is 2.x . This runs a test against emcee>3. Check with python3 -c "import emcee; print(emcee.__version__)"

conda create --name test_emcee_3  
conda install -n test_emcee_3 pytest pytest-cov
source activate test_emcee_3
conda install pip
pip install "emcee>=3" 
python3 -c "import emcee; print(emcee.__version__)"  #!! must be 3x
pip install GPy matplotlib mock pyDOE pytest-lazy-fixture sobol_seq
python3 -m pytest -x --cache-clear

source deactivate test_emcee_3  
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
